### PR TITLE
various cleanups for linux/mac build, also use static zlib

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+*.exe
+*.o
+dmf2mod

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,16 @@
 OBJS	= dmf2mod.o mod.o dmf.o
 SOURCE	= dmf2mod.c mod.c dmf.c
 HEADER	= mod.h dmf.h zconf.h zlib.h
+
+ifeq ($(OS),Windows_NT)
 OUT	= dmf2mod.exe
+else
+OUT	= dmf2mod
+endif
+
 CC	 = gcc
-FLAGS	 = -g -c -Wall -Wno-unknown-pragmas
-LFLAGS	 = -lm -lz -Lzlib 
+FLAGS	 = -Izlib -g -c -Wall -Wno-unknown-pragmas
+LFLAGS	 = -lm zlib/libz.a
 
 all: $(OBJS)
 	$(CC) -g $(OBJS) -o $(OUT) $(LFLAGS)

--- a/build
+++ b/build
@@ -3,8 +3,7 @@
 # Build script for Linux / Mac 
 
 cd ./zlib
-sudo ./configure
-sudo make
+./configure
+make
 cd ../
-sudo make 
-sudo mv "./dmf2mod.exe" "./dmf2mod"
+make 

--- a/dmf2mod.c
+++ b/dmf2mod.c
@@ -29,7 +29,7 @@ int main(int argc, char* argv[])
 
     if (argc == 1) 
     {
-        printHelp(); 
+        printHelp(argv); 
         exit(0);
     }
     else if (argc == 2) 
@@ -119,10 +119,10 @@ int main(int argc, char* argv[])
     return 0; 
 }
 
-void printHelp()
+void printHelp(char* argv[])
 {
     printf("dmf2mod v%s \nCreated by Dalton Messmer <messmer.dalton@gmail.com>\n", DMF2MOD_VERSION);
-    printf("Usage: .\\dmf2mod.exe output_file.mod deflemask_game_boy_file.dmf [options]\n");
+    printf("Usage: %s output_file.mod deflemask_game_boy_file.dmf [options]\n", argv[0]);
     printf("Options:\n");
     printf("%-25s%s\n","--downsample", "Allow wavetables to lose information through downsampling.");
     printf("%-25s%s\n", "--effects=<MIN, MAX>", "The number of ProTracker effects to use. (Default: MAX)"); 


### PR DESCRIPTION
* add .gitignore for build outputs
* update the `Makefile` to statically link zlib, and find the zlib headers properly
* update the `build` script to be executable by default, and to build as a normal user
* make the "usage" output match how the command was called, so it doesn't say `.exe` when running on mac/linux