### PR TITLE
Unified module data representation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.11)
+cmake_minimum_required(VERSION 3.14)
 
 project(dmf2mod VERSION "0.1.0")
 

--- a/include/core/conversion_options_base.h
+++ b/include/core/conversion_options_base.h
@@ -36,7 +36,7 @@ public:
      * Create a new ConversionOptions object for the desired module type
      */
     template <class moduleClass, 
-        class = std::enable_if_t<std::is_base_of<ModuleInterface<moduleClass, class moduleClass::OptionsType>, moduleClass>{}>>
+        class = std::enable_if_t<std::is_base_of_v<ModuleInterface<moduleClass, class moduleClass::OptionsType>, moduleClass>>>
     static ConversionOptionsPtr Create()
     {
         return ModuleInterface<moduleClass, class moduleClass::OptionsType>::m_Info.m_CreateOptionsFunc();
@@ -55,7 +55,7 @@ public:
     /*
      * Cast an options pointer to a pointer of a derived type
      */
-    template <class Derived, class = std::enable_if_t<std::is_base_of<ConversionOptionsInterface<Derived>, Derived>{}>>
+    template <class Derived, class = std::enable_if_t<std::is_base_of_v<ConversionOptionsInterface<Derived>, Derived>>>
     const Derived* Cast() const
     {
         return static_cast<const Derived*>(this);
@@ -89,7 +89,7 @@ public:
      */
     virtual void PrintHelp() const = 0;
 
-    template <class optionsClass, class = std::enable_if_t<std::is_base_of<ConversionOptionsInterface<optionsClass>, optionsClass>{}>>
+    template <class optionsClass, class = std::enable_if_t<std::is_base_of_v<ConversionOptionsInterface<optionsClass>, optionsClass>>>
     static void PrintHelp()
     {
         PrintHelp(ConversionOptionsInterface<optionsClass>::GetTypeStatic());

--- a/include/core/data.h
+++ b/include/core/data.h
@@ -1,0 +1,232 @@
+/*
+    pattern.h
+    Written by Dalton Messmer <messmer.dalton@gmail.com>.
+
+    Defines a data structure for storing patterns + helper functions.
+*/
+
+#pragma once
+
+#include "note.h"
+
+#include <vector>
+#include <tuple>
+#include <algorithm>
+#include <type_traits>
+
+namespace d2m {
+
+// Different modules have significantly different per-channel row contents, so 
+//  providing one single generic implementation for use by every module doesn't
+//  make much sense. Each module should provide their own Row implementation.
+
+template <class ModuleClass>
+struct Row
+{
+    NoteSlot note;
+};
+
+template <class ModuleClass>
+struct ChannelMetadata {};
+
+template <class ModuleClass>
+struct PatternMetadata {};
+
+template <class ModuleClass>
+class ModuleData
+{
+public:
+    using RowType = Row<ModuleClass>;
+    using ChannelMetadataType = ChannelMetadata<ModuleClass>;
+    using PatternMetadataType = PatternMetadata<ModuleClass>;
+    using PatternType = RowType*; // A pattern is an array of rows
+
+    ModuleData() : m_Initialized(false) {}
+    ~ModuleData() { CleanUp(); }
+
+    void InitializePatternMatrix(unsigned channels, unsigned orders, unsigned rows)
+    {
+        //if (m_Initialized) CleanUp();
+
+        m_NumChannels = channels;
+        m_NumOrders = orders;
+
+        // m_PatterMatrixValues[channel][pattern matrix row]
+        m_PatternIds.resize(channels);
+
+        for (unsigned i = 0; i < channels; ++i)
+        {
+            m_PatternIds[i].resize(orders);
+        }
+    }
+
+    void InitializePatterns()
+    {
+        // m_Patterns[channel][pattern id (not order!)][pattern row number]
+        m_Patterns.resize(GetNumChannels());
+        if constexpr (!std::is_empty_v<PatternMetadataType>)
+        {
+            // Only set it if it's going to be used
+            m_PatternMetadata.resize(GetNumChannels());
+        }
+
+        for (unsigned channel = 0; channel < GetNumChannels(); ++channel)
+        {
+            const unsigned totalPatterns = m_NumPatterns[channel];
+            m_Patterns[channel] = new PatternType[totalPatterns];
+
+            for (unsigned patternNumber = 0; patternNumber < totalPatterns; ++patternNumber)
+            {
+                m_Patterns[channel][patternNumber] = new RowType[GetNumRows()]();
+                if constexpr (!std::is_empty_v<PatternMetadataType>)
+                {
+                    // Only set it if it's going to be used
+                    m_PatternMetadata[channel].resize(totalPatterns);
+                }
+            }
+        }
+    }
+
+    void InitializeChannels()
+    {
+        // Call this after all the pattern IDs are set
+        m_NumPatterns.resize(m_NumChannels);
+
+        for (unsigned chan = 0; chan < m_NumChannels; ++chan)
+        {
+            m_NumPatterns[chan] = *std::max_element(m_PatternIds[chan].begin(), m_PatternIds[chan].end()) + 1;
+        }
+
+        if constexpr (!std::is_empty_v<ChannelMetadataType>)
+        {
+            // Only set it if it's going to be used
+            m_ChannelMetadata.resize(m_NumChannels);
+        }
+    }
+
+    /////// DIRECT ACCESS GETTERS ///////
+
+    inline const std::vector<std::vector<uint8_t>>& PatternIdsRef() const { return m_PatternIds; }
+    inline std::vector<std::vector<uint8_t>>& PatternIdsRef() { return m_PatternIds; }
+
+    inline const std::vector<uint8_t>& NumPatternsRef() const { return m_NumPatterns; }
+    inline std::vector<uint8_t>& NumPatternsRef() { return m_NumPatterns; }
+
+    inline const std::vector<PatternType*>& PatternsRef() const { return m_Patterns; }
+    inline std::vector<PatternType*>& PatternsRef() { return m_Patterns; }
+
+    inline const std::vector<ChannelMetadataType>& ChannelMetadataRef() const { return m_ChannelMetadata; }
+    inline std::vector<ChannelMetadataType>& ChannelMetadataRef() { return m_ChannelMetadata; }
+
+    inline const std::vector<std::vector<PatternMetadataType>>& PatternMetadataRef() const { return m_PatternMetadata; }
+    inline std::vector<std::vector<PatternMetadataType>>& PatternMetadataRef() { return m_PatternMetadata; }
+
+    /////// GETTERS ///////
+
+    inline unsigned GetNumChannels() const { return m_NumChannels; }
+    inline unsigned GetNumOrders() const { return m_NumOrders; }
+    inline unsigned GetNumRows() const { return m_NumRows; }
+
+    inline uint8_t GetPatternId(unsigned channel, unsigned order) const { return m_PatternIds[channel][order]; }
+
+    inline uint8_t GetNumPatterns(unsigned channel) const { return m_NumPatterns[channel]; }
+
+    inline PatternType GetPattern(unsigned channel, unsigned order) const { return m_Patterns[channel][GetPatternId(channel, order)]; }
+
+    inline PatternType GetPatternById(unsigned channel, unsigned patternId) const { return m_Patterns[channel][patternId]; }
+
+    inline const RowType& GetRow(unsigned channel, unsigned order, unsigned row) const
+    {
+        return m_Patterns[channel][m_PatternIds[channel][order]][row];
+    }
+
+    inline const RowType& GetRowById(unsigned channel, unsigned patternId, unsigned row) const
+    {
+        return m_Patterns[channel][patternId][row];
+    }
+
+    inline const ChannelMetadataType& GetChannelMetadata(unsigned channel) const
+    {
+        return m_ChannelMetadata[channel];
+    }
+
+    inline const PatternMetadataType& GetPatternMetadata(unsigned channel, unsigned pattern) const
+    {
+        return m_PatternMetadata[channel][pattern];
+    }
+
+    /////// SETTERS ///////
+
+    inline void SetPatternId(unsigned channel, unsigned order, uint8_t patternId) { m_PatternIds[channel][order] = patternId; }
+
+    inline void SetNumPatterns(unsigned channel, uint8_t numPatterns) { m_NumPatterns[channel] = numPatterns; }
+
+    // TODO: Deep copy?
+    inline void SetPattern(unsigned channel, unsigned order, PatternType&& pattern) { m_Patterns[channel][GetPatternId(channel, order)] = std::move(pattern); }
+
+    // TODO: Deep copy?
+    inline void GetPatternById(unsigned channel, unsigned patternId, PatternType&& pattern) { m_Patterns[channel][patternId] = std::move(pattern); }
+
+    inline void SetRow(unsigned channel, unsigned order, unsigned row, const RowType& rowValue)
+    {
+        m_Patterns[channel][m_PatternIds[channel][order]][row] = rowValue;
+    }
+
+    inline void SetRowById(unsigned channel, unsigned patternId, unsigned row, const RowType& rowValue)
+    {
+        m_Patterns[channel][patternId][row] = rowValue;
+    }
+
+    inline void SetChannelMetadata(unsigned channel, const ChannelMetadataType& channelMetadata)
+    {
+        m_ChannelMetadata[channel] = channelMetadata;
+    }
+
+    inline void SetPatternMetadata(unsigned channel, unsigned pattern, const PatternMetadataType& patternMetadata)
+    {
+        m_PatternMetadata[channel][pattern] = patternMetadata;
+    }
+
+    void CleanUp()
+    {
+        if (!m_NumPatterns.empty())
+        {
+            for (unsigned channel = 0; channel < m_NumChannels; ++channel)
+            {
+                for (unsigned i = 0; i < m_NumPatterns[channel]; ++i)
+                {
+                    delete[] m_Patterns[channel][i];
+                    m_Patterns[channel][i] = nullptr;
+                }
+                delete[] m_Patterns[channel];
+                m_Patterns[channel] = nullptr;
+            }
+            m_Patterns.clear();
+        }
+        m_NumPatterns.clear();
+        m_PatternIds.clear();
+
+        m_Initialized = false;
+    }
+
+private:
+
+    bool m_Initialized;
+
+    unsigned        m_NumChannels;
+    unsigned        m_NumOrders;    // Total orders (pattern matrix rows)
+    unsigned        m_NumRows;      // Rows per pattern
+
+    // Pattern matrix
+    std::vector<std::vector<uint8_t>>   m_PatternIds;  // Stores patterns IDs for each order and channel in the pattern matrix
+    std::vector<uint8_t>                m_NumPatterns; // Patterns per channel
+
+    // Pattern info
+    std::vector<PatternType*>   m_Patterns; // [channel][pattern id]
+
+    // Metadata (optional module-specific info)
+    std::vector<ChannelMetadataType> m_ChannelMetadata; // [channel]
+    std::vector<std::vector<PatternMetadataType>> m_PatternMetadata; // [channel][pattern id]
+};
+
+} // namespace d2m

--- a/include/core/data.h
+++ b/include/core/data.h
@@ -15,25 +15,22 @@
 
 namespace d2m {
 
+enum class DataStorageType
+{
+    None,
+    COR,  // Iteration order: Channels --> Orders --> (Pattern) Rows
+    ORC,  // Iteration order: Orders --> (Pattern) Rows --> Channels
+};
+
 /*
     Global data for a module. This is information such as the title and author.
     Can be customized if a module type has more global information to be stored.
 */
 
-namespace PatternStorageType
-{
-    enum PatternStorageType : uint16_t
-    {
-        NONE = 0,
-        COR,
-        ORC,
-    };
-};
-
-template <uint16_t StorageType = PatternStorageType::COR>
+template <DataStorageType DataStorage = DataStorageType::None>
 struct ModuleGlobalDataGeneric
 {
-    static constexpr uint16_t _StorageType = StorageType;
+    static constexpr DataStorageType StorageType = DataStorage;
     std::string title;
     std::string author;
 };
@@ -67,7 +64,7 @@ struct ChannelMetadataGeneric
 };
 
 template <class ModuleClass>
-struct ChannelMetadata : public ChannelMetadata {};
+struct ChannelMetadata : public ChannelMetadataGeneric {};
 
 struct PatternMetadataGeneric
 {
@@ -96,30 +93,40 @@ namespace detail
 
     class ModuleDataStorageBase
     {
-        virtual void CleanUp() = 0;
-        virtual void AllocatePatternMatrix(unsigned channels, unsigned orders) = 0;
-        virtual void AllocatePatterns() = 0;
-        virtual void AllocateChannels(unsigned channels) = 0;
+    public:
+        inline unsigned GetNumChannels() const { return m_NumChannels; }
+        inline unsigned GetNumOrders() const { return m_NumOrders; }
+        inline unsigned GetNumRows() const { return m_NumRows; }
+    protected:
+        virtual void CleanUpData() = 0;
+        virtual void SetPatternMatrix() = 0;
+        virtual void SetNumPatterns() = 0;
+        virtual void SetPatterns() = 0;
+        unsigned m_NumChannels;
+        unsigned m_NumOrders;    // Total orders (pattern matrix rows)
+        unsigned m_NumRows;      // Rows per pattern
     };
 
-    template <uint16_t StorageType, class ModuleClass>
-    class ModuleDataStorage
+    template <DataStorageType StorageType, class ModuleClass>
+    class ModuleDataStorage : public ModuleDataStorageBase
     {
-    public:
-        static_assert(false, "This non-specialized primary template should never be used");
-        void CleanUp() override {}
-        void AllocatePatternMatrix(unsigned channels, unsigned orders) override {}
-        void AllocatePatterns(unsigned channels, unsigned patterns, unsigned rows) override {}
-        void AllocateChannels(unsigned channels) override {}
+    protected:
+        ModuleDataStorage() = delete; // This non-specialized primary template should never be used
+        ModuleDataStorage(const ModuleDataStorage&) = delete;
+        ModuleDataStorage(ModuleDataStorage&&) = delete;
+        void CleanUpData() override {}
+        void SetPatternMatrix() override {}
+        void SetNumPatterns() override {}
+        void SetPatterns() override {}
     };
 
     template <class ModuleClass>
-    class ModuleDataStorage<PatternStorageType::COR, ModuleClass>
+    class ModuleDataStorage<DataStorageType::COR, ModuleClass> : public ModuleDataStorageBase
     {
-    public:
+    protected:
         ModuleDataStorage() {}
-        ~ModuleDataStorage() { CleanUp(); }
-        void CleanUp()
+        ~ModuleDataStorage() { CleanUpData(); }
+        void CleanUpData() override
         {
             if (!m_NumPatterns.empty())
             {
@@ -142,51 +149,51 @@ namespace detail
             m_PatternMetadata.clear();
         }
 
-        void AllocatePatternMatrix(unsigned channels, unsigned orders) override
+        void SetPatternMatrix() override
         {
-            // m_PatterMatrixValues[channel][pattern matrix row]
-            m_PatternMatrix.resize(channels);
+            m_PatternMatrix.resize(m_NumChannels);
 
-            for (unsigned i = 0; i < channels; ++i)
+            for (unsigned channel = 0; channel < m_NumChannels; ++channel)
             {
-                m_PatternMatrix[i].resize(orders);
+                m_PatternMatrix[channel].resize(m_NumOrders);
             }
         }
-        void AllocatePatterns(unsigned channels, unsigned patterns, unsigned rows) override
+        void SetNumPatterns() override
         {
-            // m_Patterns[channel][pattern id (not order!)][pattern row number]
-            m_Patterns.resize(channels);
+            m_NumPatterns.resize(m_NumChannels);
+
+            for (unsigned channel = 0; channel < m_NumChannels; ++channel)
+            {
+                m_NumPatterns[channel] = *std::max_element(m_PatternMatrix[channel].begin(), m_PatternMatrix[channel].end()) + 1;
+            }
+        }
+        void SetPatterns() override
+        {
+            m_Patterns.resize(m_NumChannels);
             if constexpr (!std::is_empty_v<PatternMetadataType>)
             {
                 // Only set it if it's going to be used
-                m_PatternMetadata.resize(channels);
+                m_PatternMetadata.resize(m_NumChannels);
             }
 
-            for (unsigned channel = 0; channel < channels; ++channel)
+            for (unsigned channel = 0; channel < m_NumChannels; ++channel)
             {
-                m_Patterns[channel] = new PatternType[patterns];
+                const uint8_t numPatterns = m_NumPatterns[channel];
+                m_Patterns[channel] = new PatternType[numPatterns];
 
-                for (unsigned patternId = 0; patternId < patterns; ++patternId)
+                for (unsigned patternId = 0; patternId < numPatterns; ++patternId)
                 {
-                    m_Patterns[channel][patternId] = new RowType[rows]();
+                    m_Patterns[channel][patternId] = new RowType[m_NumRows]();
                     if constexpr (!std::is_empty_v<PatternMetadataType>)
                     {
                         // Only set it if it's going to be used
-                        m_PatternMetadata[channel].resize(patterns);
+                        m_PatternMetadata[channel].resize(numPatterns);
                     }
                 }
             }
         }
-        void AllocateChannels(unsigned channels) override
-        {
-            m_NumPatterns.resize(channels);
 
-            for (unsigned chan = 0; chan < channels; ++chan)
-            {
-                m_NumPatterns[chan] = *std::max_element(m_PatternMatrix[chan].begin(), m_PatternMatrix[chan].end()) + 1;
-            }
-        }
-
+    public:
         using RowType = Row<ModuleClass>;
         using PatternType = RowType*; // [row]
 
@@ -196,15 +203,114 @@ namespace detail
         using PatternMetadataType = PatternMetadata<ModuleClass>;
         using PatternMetadataStorageType = std::vector<std::vector<PatternMetadataType>>; // [channel][pattern id]
 
+        inline uint8_t GetPatternId(unsigned channel, unsigned order) const { return m_PatternMatrix[channel][order]; }
+        inline void SetPatternId(unsigned channel, unsigned order, uint8_t patternId) { m_PatternMatrix[channel][order] = patternId; }
+        inline uint8_t GetNumPatterns(unsigned channel) const { return m_NumPatterns[channel]; }
+        inline void SetNumPatterns(unsigned channel, uint8_t numPatterns) { m_NumPatterns[channel] = numPatterns; }
+        inline PatternType GetPattern(unsigned channel, unsigned order) const { return m_Patterns[channel][GetPatternId(channel, order)]; }
+        inline void SetPattern(unsigned channel, unsigned order, PatternType&& pattern) { m_Patterns[channel][GetPatternId(channel, order)] = std::move(pattern); } // TODO: Deep copy?
+        inline PatternType GetPatternById(unsigned channel, unsigned patternId) const { return m_Patterns[channel][patternId]; }
+        inline void SetPatternById(unsigned channel, unsigned patternId, PatternType&& pattern) { m_Patterns[channel][patternId] = std::move(pattern); } // TODO: Deep copy?
+        inline const RowType& GetRow(unsigned channel, unsigned order, unsigned row) const { return GetPattern(channel, order)[row]; }
+        inline void SetRow(unsigned channel, unsigned order, unsigned row, const RowType& rowValue) { GetPattern(channel, order)[row] = rowValue; }
+        inline const RowType& GetRowById(unsigned channel, unsigned patternId, unsigned row) const { return GetPatternById(channel, patternId)[row]; }
+        inline void SetRowById(unsigned channel, unsigned patternId, unsigned row, const RowType& rowValue) { GetPatternById(channel, patternId)[row] = rowValue; }
+        inline const PatternMetadataType& GetPatternMetadata(unsigned channel, unsigned patternId) const { return m_PatternMetadata[channel][patternId]; }
+        inline void SetPatternMetadata(unsigned channel, unsigned patternId, const PatternMetadataType& patternMetadata) { m_PatternMetadata[channel][patternId] = patternMetadata; }
+
     protected:
-        PatternMatrixType m_PatternMatrix{};  // Stores patterns IDs for each order and channel in the pattern matrix
+        PatternMatrixType m_PatternMatrix{};  // Stores patterns IDs for each channel and order in the pattern matrix
         NumPatternsType m_NumPatterns{}; // Patterns per channel
         PatternStorageType m_Patterns{}; // [channel][pattern id]
         PatternMetadataStorageType m_PatternMetadata{}; // [channel][pattern id]
     };
 
+    template <class ModuleClass>
+    class ModuleDataStorage<DataStorageType::ORC, ModuleClass> : public ModuleDataStorageBase
+    {
+    protected:
+        ModuleDataStorage() {}
+        ~ModuleDataStorage() { CleanUpData(); }
+        void CleanUpData() override
+        {
+            for (unsigned patternId = 0; patternId < m_NumPatterns; ++patternId)
+            {
+                for (unsigned row = 0; row < m_NumRows; ++row)
+                {
+                    delete[] m_Patterns[patternId][row];
+                    m_Patterns[patternId][row] = nullptr;
+                }
+                delete[] m_Patterns[patternId];
+                m_Patterns[patternId] = nullptr;
+            }
+            m_Patterns.clear();
+
+            m_PatternMatrix.clear();
+            m_NumPatterns = 0;
+            m_PatternMetadata.clear();
+        }
+
+        void SetPatternMatrix() override
+        {
+            m_PatternMatrix.resize(m_NumOrders);
+        }
+        void SetNumPatterns() override
+        {
+            m_NumPatterns = *std::max_element(m_PatternMatrix.begin(), m_PatternMatrix.end()) + 1;
+        }
+        void SetPatterns() override
+        {
+            m_Patterns.resize(m_NumPatterns);
+            if constexpr (!std::is_empty_v<PatternMetadataType>)
+            {
+                // Only set it if it's going to be used
+                m_PatternMetadata.resize(m_NumPatterns);
+            }
+
+            for (unsigned patternId = 0; patternId < m_NumPatterns; ++patternId)
+            {
+                m_Patterns[patternId] = new RowType*[m_NumRows];
+                for (unsigned row = 0; row < m_NumRows; ++row)
+                {
+                    m_Patterns[patternId][row] = new RowType[m_NumChannels]();
+                }
+            }
+        }
+
+    public:
+        using RowType = Row<ModuleClass>;
+        using PatternType = RowType**; // [row][channel]
+
+        using PatternMatrixType = std::vector<uint8_t>; // [order] (No per-channel patterns)
+        using NumPatternsType = uint8_t; // (No per-channel patterns)
+        using PatternStorageType = std::vector<PatternType>; // [order]
+        using PatternMetadataType = PatternMetadata<ModuleClass>;
+        using PatternMetadataStorageType = std::vector<PatternMetadataType>; // [pattern id] (No per-channel patterns)
+
+        inline uint8_t GetPatternId(unsigned order) const { return m_PatternMatrix[order]; }
+        inline void SetPatternId(unsigned order, uint8_t patternId) { m_PatternMatrix[order] = patternId; }
+        inline uint8_t GetNumPatterns() const { return m_NumPatterns; }
+        inline void SetNumPatterns(uint8_t numPatterns) { m_NumPatterns = numPatterns; }
+        inline PatternType GetPattern(unsigned order) const { return m_Patterns[GetPatternId(order)]; }
+        inline void SetPattern(unsigned order, PatternType&& pattern) { m_Patterns[GetPatternId(order)] = std::move(pattern); } // TODO: Deep copy?
+        inline PatternType GetPatternById(unsigned patternId) const { return m_Patterns[patternId]; }
+        inline void SetPatternById(unsigned patternId, PatternType&& pattern) { m_Patterns[patternId] = std::move(pattern); } // TODO: Deep copy?
+        inline const RowType& GetRow(unsigned channel, unsigned order, unsigned row) const { return GetPattern(order)[row][channel]; }
+        inline void SetRow(unsigned channel, unsigned order, unsigned row, const RowType& rowValue) { GetPattern(order)[row][channel] = rowValue; }
+        inline const RowType& GetRowById(unsigned channel, unsigned patternId, unsigned row) const { return GetPatternById(patternId)[row][channel]; }
+        inline void SetRowById(unsigned channel, unsigned patternId, unsigned row, const RowType& rowValue) { GetPatternById(patternId)[row][channel] = rowValue; }
+        inline const PatternMetadataType& GetPatternMetadata(unsigned patternId) const { return m_PatternMetadata[patternId]; }
+        inline void SetPatternMetadata(unsigned patternId, const PatternMetadataType& patternMetadata) { m_PatternMetadata[patternId] = patternMetadata; }
+
+    protected:
+        PatternMatrixType m_PatternMatrix{};  // Stores patterns IDs for each order in the pattern matrix
+        NumPatternsType m_NumPatterns{}; // Number of patterns
+        PatternStorageType m_Patterns{}; // [pattern id]
+        PatternMetadataStorageType m_PatternMetadata{}; // [pattern id]
+    };
+
     /*
-        TODO: Define additional ModuleDataStorage specializations here
+        Define additional ModuleDataStorage specializations here as needed
     */
 }
 
@@ -214,7 +320,7 @@ namespace detail
 */
 
 template <class ModuleClass>
-class ModuleData : public detail::ModuleDataStorage<ModuleGlobalData<ModuleClass>::_StorageType, ModuleClass>
+class ModuleData : public detail::ModuleDataStorage<ModuleGlobalData<ModuleClass>::StorageType, ModuleClass>
 {
 public:
     using RowType = Row<ModuleClass>;
@@ -222,10 +328,10 @@ public:
     using PatternMetadataType = PatternMetadata<ModuleClass>;
     using GlobalDataType = ModuleGlobalData<ModuleClass>;
 
-    static constexpr uint16_t m_StorageType = GlobalDataType::_StorageType;
-    static_assert(m_StorageType != 0, "Storage type must be defined for ModuleData through the ModuleGlobalData struct");
+    static constexpr DataStorageType StorageType = GlobalDataType::StorageType;
+    static_assert(StorageType != DataStorageType::None, "Storage type must be defined for ModuleData through the ModuleGlobalData struct");
 
-    using Storage = detail::ModuleDataStorage<m_StorageType, ModuleClass>;
+    using Storage = typename detail::ModuleDataStorage<StorageType, ModuleClass>;
 
     ModuleData() { CleanUp(); }
     ~ModuleData() { CleanUp(); }
@@ -233,146 +339,82 @@ public:
     // This is the 1st initialization method to call
     void AllocatePatternMatrix(unsigned channels, unsigned orders, unsigned rows)
     {
-        CleanUp();
-        Storage::CleanUp();
+        Storage::CleanUpData();
 
-        m_NumChannels = channels;
-        m_NumOrders = orders;
-        m_NumRows = rows;
+        Storage::m_NumChannels = channels;
+        Storage::m_NumOrders = orders;
+        Storage::m_NumRows = rows;
 
-        Storage::AllocatePatternMatrix(channels, orders);
+        Storage::SetPatternMatrix();
     }
 
     // This is the 2nd initialization method to call
-    void AllocatePatterns()
-    {
-        Storage::AllocatePatterns();
-    }
-
-    // This is the 3rd and final initialization method to call
     void AllocateChannels()
     {
         // Call this after all the pattern IDs are set
-        Storage::AllocateChannels(m_NumChannels);
+        Storage::SetNumPatterns();
 
         if constexpr (!std::is_empty_v<ChannelMetadataType>)
         {
             // Only set it if it's going to be used
-            m_ChannelMetadata.resize(m_NumChannels);
+            m_ChannelMetadata.resize(Storage::m_NumChannels);
         }
+    }
+
+    // This is the 3rd and final initialization method to call
+    void AllocatePatterns()
+    {
+        Storage::SetPatterns();
     }
 
     /////// DIRECT ACCESS GETTERS ///////
 
-    inline const PatternMatrixType& PatternMatrixRef() const { return m_PatternMatrix; }
-    inline PatternMatrixType& PatternMatrixRef() { return m_PatternMatrix; }
+    inline const typename Storage::PatternMatrixType& PatternMatrixRef() const { return Storage::m_PatternMatrix; }
+    inline typename Storage::PatternMatrixType& PatternMatrixRef() { return Storage::m_PatternMatrix; }
 
-    inline const NumPatternsType& NumPatternsRef() const { return m_NumPatterns; }
-    inline NumPatternsType& NumPatternsRef() { return m_NumPatterns; }
+    inline const typename Storage::NumPatternsType& NumPatternsRef() const { return Storage::m_NumPatterns; }
+    inline typename Storage::NumPatternsType& NumPatternsRef() { return Storage::m_NumPatterns; }
 
-    inline const PatternStorageType& PatternsRef() const { return m_Patterns; }
-    inline PatternStorageType& PatternsRef() { return m_Patterns; }
+    inline const typename Storage::PatternStorageType& PatternsRef() const { return Storage::m_Patterns; }
+    inline typename Storage::PatternStorageType& PatternsRef() { return Storage::m_Patterns; }
 
-    inline const PatternMetadataStorageType& PatternMetadataRef() const { return m_PatternMetadata; }
-    inline PatternMetadataStorageType& PatternMetadataRef() { return m_PatternMetadata; }
+    inline const typename Storage::PatternMetadataStorageType& PatternMetadataRef() const { return Storage::m_PatternMetadata; }
+    inline typename Storage::PatternMetadataStorageType& PatternMetadataRef() { return Storage::m_PatternMetadata; }
 
     inline const std::vector<ChannelMetadataType>& ChannelMetadataRef() const { return m_ChannelMetadata; }
     inline std::vector<ChannelMetadataType>& ChannelMetadataRef() { return m_ChannelMetadata; }
 
-    inline const std::unique_ptr<GlobalDataType>& GlobalData() const { return m_GlobalData; }
-    inline std::unique_ptr<GlobalDataType>& GlobalData() { return m_GlobalData; }
+    inline const GlobalDataType& GlobalData() const { return m_GlobalData; }
+    inline GlobalDataType& GlobalData() { return m_GlobalData; }
 
     /////// GETTERS / SETTERS ///////
-
-    inline unsigned GetNumChannels() const { return m_NumChannels; }
-    inline unsigned GetNumOrders() const { return m_NumOrders; }
-    inline unsigned GetNumRows() const { return m_NumRows; }
 
     inline const ChannelMetadataType& GetChannelMetadata(unsigned channel) const { return m_ChannelMetadata[channel]; }
     inline void SetChannelMetadata(unsigned channel, const ChannelMetadataType& channelMetadata) { m_ChannelMetadata[channel] = channelMetadata; }
 
-    static inline constexpr PatternStorageType GetStorageType() const { return m_StorageType; }
-
-    /////// StorageType-dependent getters/setters (for convenience) ///////
-
-    // TODO: Define these in the specializations instead
-
-    // PatternId
-    if constexpr (m_StorageType == PatternStorageType::ORC) {
-        inline uint8_t GetPatternId(unsigned order) const { return m_PatternMatrix[order]; }
-        inline void SetPatternId(unsigned order, uint8_t patternId) { m_PatternMatrix[order] = patternId; }
-    } else if constexpr (m_StorageType == PatternStorageType::COR) {
-        inline uint8_t GetPatternId(unsigned channel, unsigned order) const { return m_PatternMatrix[channel][order]; }
-        inline void SetPatternId(unsigned channel, unsigned order, uint8_t patternId) { m_PatternMatrix[channel][order] = patternId; }
-    }
-
-    // NumPatterns
-    if constexpr (m_StorageType == PatternStorageType::ORC) {
-        inline uint8_t GetNumPatterns() const { return m_NumPatterns; }
-        inline void SetNumPatterns(uint8_t numPatterns) { m_NumPatterns = numPatterns; }
-    } else if constexpr (m_StorageType == PatternStorageType::COR) {
-        inline uint8_t GetNumPatterns(unsigned channel) const { return m_NumPatterns[channel]; }
-        inline void SetNumPatterns(unsigned channel, uint8_t numPatterns) { m_NumPatterns[channel] = numPatterns; }
-    }
-
-    // Pattern / PatternById
-    if constexpr (m_StorageType == PatternStorageType::ORC) {
-        inline PatternType GetPattern(unsigned order) const { return m_Patterns[GetPatternId(order)]; }
-        inline void SetPattern(unsigned order, PatternType&& pattern) { m_Patterns[GetPatternId(order)] = std::move(pattern); } // TODO: Deep copy?
-        inline PatternType GetPatternById(unsigned patternId) const { return m_Patterns[patternId]; }
-        inline void SetPatternById(unsigned patternId, PatternType&& pattern) { m_Patterns[patternId] = std::move(pattern); } // TODO: Deep copy?
-    } else if constexpr (m_StorageType == PatternStorageType::COR) {
-        inline PatternType GetPattern(unsigned channel, unsigned order) const { return m_Patterns[channel][GetPatternId(channel, order)]; }
-        inline void SetPattern(unsigned channel, unsigned order, PatternType&& pattern) { m_Patterns[channel][GetPatternId(channel, order)] = std::move(pattern); } // TODO: Deep copy?
-        inline PatternType GetPatternById(unsigned channel, unsigned patternId) const { return m_Patterns[channel][patternId]; }
-        inline void SetPatternById(unsigned channel, unsigned patternId, PatternType&& pattern) { m_Patterns[channel][patternId] = std::move(pattern); } // TODO: Deep copy?
-    }
-
-    // Row / RowById
-    if constexpr (m_StorageType == PatternStorageType::ORC) {
-        inline const RowType& GetRow(unsigned channel, unsigned order, unsigned row) const { return GetPattern(order)[row][channel]; }
-        inline void SetRow(unsigned channel, unsigned order, unsigned row, const RowType& rowValue) { GetPattern(order)[row][channel] = rowValue; }
-        inline const RowType& GetRowById(unsigned channel, unsigned patternId, unsigned row) const { return GetPatternById(patternId)[row][channel]; }
-        inline void SetRowById(unsigned channel, unsigned patternId, unsigned row, const RowType& rowValue) { GetPatternById(patternId)[row][channel] = rowValue; }
-    } else if constexpr (m_StorageType == PatternStorageType::COR) {
-        inline const RowType& GetRow(unsigned channel, unsigned order, unsigned row) const { return GetPattern(channel, order)[row]; }
-        inline void SetRow(unsigned channel, unsigned order, unsigned row, const RowType& rowValue) { GetPattern(channel, order)[row] = rowValue; }
-        inline const RowType& GetRowById(unsigned channel, unsigned patternId, unsigned row) const { return GetPatternById(channel, patternId)[row]; }
-        inline void SetRowById(unsigned channel, unsigned patternId, unsigned row, const RowType& rowValue) { GetPatternById(channel, patternId)[row] = rowValue; }
-    }
-
-    // PatternMetadata
-    if constexpr (m_StorageType == PatternStorageType::ORC) {
-        inline const PatternMetadataType& GetPatternMetadata(unsigned patternId) const { return m_PatternMetadata[patternId]; }
-        inline void SetPatternMetadata(unsigned patternId, const PatternMetadataType& patternMetadata) { m_PatternMetadata[patternId] = patternMetadata; }
-    } else if constexpr (m_StorageType == PatternStorageType::COR) {
-        inline const PatternMetadataType& GetPatternMetadata(unsigned channel, unsigned patternId) const { return m_PatternMetadata[channel][patternId]; }
-        inline void SetPatternMetadata(unsigned channel, unsigned patternId, const PatternMetadataType& patternMetadata) { m_PatternMetadata[channel][patternId] = patternMetadata; }
-    }
+    static inline constexpr DataStorageType GetStorageType() { return StorageType; }
 
     /////// Other
 
     void CleanUp()
     {
-        m_NumChannels = 0;
-        m_NumOrders = 0;
-        m_NumRows = 0;
+        Storage::CleanUpData();
+
+        Storage::m_NumChannels = 0;
+        Storage::m_NumOrders = 0;
+        Storage::m_NumRows = 0;
 
         m_ChannelMetadata.clear();
-        m_GlobalData.reset();
+        m_GlobalData = {};
     }
 
 private:
 
-    unsigned        m_NumChannels;
-    unsigned        m_NumOrders;    // Total orders (pattern matrix rows)
-    unsigned        m_NumRows;      // Rows per pattern
-
     // Metadata (optional module-specific info)
     std::vector<ChannelMetadataType> m_ChannelMetadata; // [channel]
 
-    // Wrapping this in a smart pointer avoids the "explicit specialization must precede its first use" error:
-    std::unique_ptr<GlobalDataType> m_GlobalData;   // Global information about a particular module file
+    // Global information about a particular module file
+    GlobalDataType m_GlobalData;
 };
 
 } // namespace d2m

--- a/include/core/data.h
+++ b/include/core/data.h
@@ -16,16 +16,44 @@
 namespace d2m {
 
 /*
+    Global data for a module. This is information such as the title and author.
+    Can be customized if a module type has more global information to be stored.
+*/
+
+namespace PatternStorageType
+{
+    enum PatternStorageType : uint16_t
+    {
+        NONE = 0,
+        COR,
+        ORC,
+    };
+};
+
+template <uint16_t StorageType = PatternStorageType::COR>
+struct ModuleGlobalDataGeneric
+{
+    static constexpr uint16_t _StorageType = StorageType;
+    std::string title;
+    std::string author;
+};
+
+template <class ModuleClass>
+struct ModuleGlobalData : public ModuleGlobalDataGeneric<> {};
+
+/*
     Different modules have significantly different per-channel row contents, so
     providing one single generic implementation for use by every module doesn't
     make much sense. Each module should provide their own Row implementation.
 */
 
-template <class ModuleClass>
-struct Row
+struct RowGeneric
 {
     NoteSlot note;
 };
+
+template <class ModuleClass>
+struct Row : public RowGeneric {};
 
 /*
     Some module formats contain additional data for each channel or row.
@@ -33,11 +61,152 @@ struct Row
     for any module format which requires it.
 */
 
-template <class ModuleClass>
-struct ChannelMetadata {};
+struct ChannelMetadataGeneric
+{
+    // No defaults at this time
+};
 
 template <class ModuleClass>
-struct PatternMetadata {};
+struct ChannelMetadata : public ChannelMetadata {};
+
+struct PatternMetadataGeneric
+{
+    // No defaults at this time
+};
+
+template <class ModuleClass>
+struct PatternMetadata : public PatternMetadataGeneric {};
+
+
+namespace detail
+{
+    /*
+     * The class templates below allow different module formats in dmf2mod to choose an underlying
+     * storage data structure that works best for them while maintaining a common interface to
+     * that data.
+     * 
+     * The motivation for this is that different module formats store their pattern matrix and
+     * pattern data differently, so this affects the kind of C++ data structures their module data
+     * more naturally maps to. If a data structure that maps more naturally to the module's data is used,
+     * better performance can be achieved when iterating through the data while importing/exporting.
+     * Additionally, some formats such as MOD do not have per-channel patterns, meaning that all channels
+     * are essentially linked together as far as patterns are concerned. This necessitates a flexible
+     * way of storing module data which can work for any module format.
+     */
+
+    class ModuleDataStorageBase
+    {
+        virtual void CleanUp() = 0;
+        virtual void AllocatePatternMatrix(unsigned channels, unsigned orders) = 0;
+        virtual void AllocatePatterns() = 0;
+        virtual void AllocateChannels(unsigned channels) = 0;
+    };
+
+    template <uint16_t StorageType, class ModuleClass>
+    class ModuleDataStorage
+    {
+    public:
+        static_assert(false, "This non-specialized primary template should never be used");
+        void CleanUp() override {}
+        void AllocatePatternMatrix(unsigned channels, unsigned orders) override {}
+        void AllocatePatterns(unsigned channels, unsigned patterns, unsigned rows) override {}
+        void AllocateChannels(unsigned channels) override {}
+    };
+
+    template <class ModuleClass>
+    class ModuleDataStorage<PatternStorageType::COR, ModuleClass>
+    {
+    public:
+        ModuleDataStorage() {}
+        ~ModuleDataStorage() { CleanUp(); }
+        void CleanUp()
+        {
+            if (!m_NumPatterns.empty())
+            {
+                unsigned channel = 0;
+                for (const auto& numPatterns : m_NumPatterns)
+                {
+                    for (unsigned patternId = 0; patternId < numPatterns; ++patternId)
+                    {
+                        delete[] m_Patterns[channel][patternId];
+                        m_Patterns[channel][patternId] = nullptr;
+                    }
+                    delete[] m_Patterns[channel];
+                    m_Patterns[channel] = nullptr;
+                    ++channel;
+                }
+                m_Patterns.clear();
+            }
+            m_PatternMatrix.clear();
+            m_NumPatterns.clear();
+            m_PatternMetadata.clear();
+        }
+
+        void AllocatePatternMatrix(unsigned channels, unsigned orders) override
+        {
+            // m_PatterMatrixValues[channel][pattern matrix row]
+            m_PatternMatrix.resize(channels);
+
+            for (unsigned i = 0; i < channels; ++i)
+            {
+                m_PatternMatrix[i].resize(orders);
+            }
+        }
+        void AllocatePatterns(unsigned channels, unsigned patterns, unsigned rows) override
+        {
+            // m_Patterns[channel][pattern id (not order!)][pattern row number]
+            m_Patterns.resize(channels);
+            if constexpr (!std::is_empty_v<PatternMetadataType>)
+            {
+                // Only set it if it's going to be used
+                m_PatternMetadata.resize(channels);
+            }
+
+            for (unsigned channel = 0; channel < channels; ++channel)
+            {
+                m_Patterns[channel] = new PatternType[patterns];
+
+                for (unsigned patternId = 0; patternId < patterns; ++patternId)
+                {
+                    m_Patterns[channel][patternId] = new RowType[rows]();
+                    if constexpr (!std::is_empty_v<PatternMetadataType>)
+                    {
+                        // Only set it if it's going to be used
+                        m_PatternMetadata[channel].resize(patterns);
+                    }
+                }
+            }
+        }
+        void AllocateChannels(unsigned channels) override
+        {
+            m_NumPatterns.resize(channels);
+
+            for (unsigned chan = 0; chan < channels; ++chan)
+            {
+                m_NumPatterns[chan] = *std::max_element(m_PatternMatrix[chan].begin(), m_PatternMatrix[chan].end()) + 1;
+            }
+        }
+
+        using RowType = Row<ModuleClass>;
+        using PatternType = RowType*; // [row]
+
+        using PatternMatrixType = std::vector<std::vector<uint8_t>>; // [channel][order]
+        using NumPatternsType = std::vector<uint8_t>; // [channel]
+        using PatternStorageType = std::vector<PatternType*>; // [channel][pattern id]
+        using PatternMetadataType = PatternMetadata<ModuleClass>;
+        using PatternMetadataStorageType = std::vector<std::vector<PatternMetadataType>>; // [channel][pattern id]
+
+    protected:
+        PatternMatrixType m_PatternMatrix{};  // Stores patterns IDs for each order and channel in the pattern matrix
+        NumPatternsType m_NumPatterns{}; // Patterns per channel
+        PatternStorageType m_Patterns{}; // [channel][pattern id]
+        PatternMetadataStorageType m_PatternMetadata{}; // [channel][pattern id]
+    };
+
+    /*
+        TODO: Define additional ModuleDataStorage specializations here
+    */
+}
 
 /*
     ModuleData stores and provides access to song data such as
@@ -45,72 +214,46 @@ struct PatternMetadata {};
 */
 
 template <class ModuleClass>
-class ModuleData
+class ModuleData : public detail::ModuleDataStorage<ModuleGlobalData<ModuleClass>::_StorageType, ModuleClass>
 {
 public:
     using RowType = Row<ModuleClass>;
     using ChannelMetadataType = ChannelMetadata<ModuleClass>;
     using PatternMetadataType = PatternMetadata<ModuleClass>;
-    using PatternType = RowType*; // A pattern is an array of rows
+    using GlobalDataType = ModuleGlobalData<ModuleClass>;
+
+    static constexpr uint16_t m_StorageType = GlobalDataType::_StorageType;
+    static_assert(m_StorageType != 0, "Storage type must be defined for ModuleData through the ModuleGlobalData struct");
+
+    using Storage = detail::ModuleDataStorage<m_StorageType, ModuleClass>;
 
     ModuleData() { CleanUp(); }
     ~ModuleData() { CleanUp(); }
 
     // This is the 1st initialization method to call
-    void InitializePatternMatrix(unsigned channels, unsigned orders, unsigned rows)
+    void AllocatePatternMatrix(unsigned channels, unsigned orders, unsigned rows)
     {
         CleanUp();
+        Storage::CleanUp();
+
         m_NumChannels = channels;
         m_NumOrders = orders;
         m_NumRows = rows;
 
-        // m_PatterMatrixValues[channel][pattern matrix row]
-        m_PatternIds.resize(channels);
-
-        for (unsigned i = 0; i < channels; ++i)
-        {
-            m_PatternIds[i].resize(orders);
-        }
+        Storage::AllocatePatternMatrix(channels, orders);
     }
 
     // This is the 2nd initialization method to call
-    void InitializePatterns()
+    void AllocatePatterns()
     {
-        // m_Patterns[channel][pattern id (not order!)][pattern row number]
-        m_Patterns.resize(GetNumChannels());
-        if constexpr (!std::is_empty_v<PatternMetadataType>)
-        {
-            // Only set it if it's going to be used
-            m_PatternMetadata.resize(GetNumChannels());
-        }
-
-        for (unsigned channel = 0; channel < GetNumChannels(); ++channel)
-        {
-            const unsigned totalPatterns = m_NumPatterns[channel];
-            m_Patterns[channel] = new PatternType[totalPatterns];
-
-            for (unsigned patternNumber = 0; patternNumber < totalPatterns; ++patternNumber)
-            {
-                m_Patterns[channel][patternNumber] = new RowType[GetNumRows()]();
-                if constexpr (!std::is_empty_v<PatternMetadataType>)
-                {
-                    // Only set it if it's going to be used
-                    m_PatternMetadata[channel].resize(totalPatterns);
-                }
-            }
-        }
+        Storage::AllocatePatterns();
     }
 
     // This is the 3rd and final initialization method to call
-    void InitializeChannels()
+    void AllocateChannels()
     {
         // Call this after all the pattern IDs are set
-        m_NumPatterns.resize(m_NumChannels);
-
-        for (unsigned chan = 0; chan < m_NumChannels; ++chan)
-        {
-            m_NumPatterns[chan] = *std::max_element(m_PatternIds[chan].begin(), m_PatternIds[chan].end()) + 1;
-        }
+        Storage::AllocateChannels(m_NumChannels);
 
         if constexpr (!std::is_empty_v<ChannelMetadataType>)
         {
@@ -121,112 +264,102 @@ public:
 
     /////// DIRECT ACCESS GETTERS ///////
 
-    inline const std::vector<std::vector<uint8_t>>& PatternIdsRef() const { return m_PatternIds; }
-    inline std::vector<std::vector<uint8_t>>& PatternIdsRef() { return m_PatternIds; }
+    inline const PatternMatrixType& PatternMatrixRef() const { return m_PatternMatrix; }
+    inline PatternMatrixType& PatternMatrixRef() { return m_PatternMatrix; }
 
-    inline const std::vector<uint8_t>& NumPatternsRef() const { return m_NumPatterns; }
-    inline std::vector<uint8_t>& NumPatternsRef() { return m_NumPatterns; }
+    inline const NumPatternsType& NumPatternsRef() const { return m_NumPatterns; }
+    inline NumPatternsType& NumPatternsRef() { return m_NumPatterns; }
 
-    inline const std::vector<PatternType*>& PatternsRef() const { return m_Patterns; }
-    inline std::vector<PatternType*>& PatternsRef() { return m_Patterns; }
+    inline const PatternStorageType& PatternsRef() const { return m_Patterns; }
+    inline PatternStorageType& PatternsRef() { return m_Patterns; }
+
+    inline const PatternMetadataStorageType& PatternMetadataRef() const { return m_PatternMetadata; }
+    inline PatternMetadataStorageType& PatternMetadataRef() { return m_PatternMetadata; }
 
     inline const std::vector<ChannelMetadataType>& ChannelMetadataRef() const { return m_ChannelMetadata; }
     inline std::vector<ChannelMetadataType>& ChannelMetadataRef() { return m_ChannelMetadata; }
 
-    inline const std::vector<std::vector<PatternMetadataType>>& PatternMetadataRef() const { return m_PatternMetadata; }
-    inline std::vector<std::vector<PatternMetadataType>>& PatternMetadataRef() { return m_PatternMetadata; }
+    inline const std::unique_ptr<GlobalDataType>& GlobalData() const { return m_GlobalData; }
+    inline std::unique_ptr<GlobalDataType>& GlobalData() { return m_GlobalData; }
 
-    /////// GETTERS ///////
+    /////// GETTERS / SETTERS ///////
 
     inline unsigned GetNumChannels() const { return m_NumChannels; }
     inline unsigned GetNumOrders() const { return m_NumOrders; }
     inline unsigned GetNumRows() const { return m_NumRows; }
 
-    inline uint8_t GetPatternId(unsigned channel, unsigned order) const { return m_PatternIds[channel][order]; }
+    inline const ChannelMetadataType& GetChannelMetadata(unsigned channel) const { return m_ChannelMetadata[channel]; }
+    inline void SetChannelMetadata(unsigned channel, const ChannelMetadataType& channelMetadata) { m_ChannelMetadata[channel] = channelMetadata; }
 
-    inline uint8_t GetNumPatterns(unsigned channel) const { return m_NumPatterns[channel]; }
+    static inline constexpr PatternStorageType GetStorageType() const { return m_StorageType; }
 
-    inline PatternType GetPattern(unsigned channel, unsigned order) const { return m_Patterns[channel][GetPatternId(channel, order)]; }
+    /////// StorageType-dependent getters/setters (for convenience) ///////
 
-    inline PatternType GetPatternById(unsigned channel, unsigned patternId) const { return m_Patterns[channel][patternId]; }
+    // TODO: Define these in the specializations instead
 
-    inline const RowType& GetRow(unsigned channel, unsigned order, unsigned row) const
-    {
-        return m_Patterns[channel][m_PatternIds[channel][order]][row];
+    // PatternId
+    if constexpr (m_StorageType == PatternStorageType::ORC) {
+        inline uint8_t GetPatternId(unsigned order) const { return m_PatternMatrix[order]; }
+        inline void SetPatternId(unsigned order, uint8_t patternId) { m_PatternMatrix[order] = patternId; }
+    } else if constexpr (m_StorageType == PatternStorageType::COR) {
+        inline uint8_t GetPatternId(unsigned channel, unsigned order) const { return m_PatternMatrix[channel][order]; }
+        inline void SetPatternId(unsigned channel, unsigned order, uint8_t patternId) { m_PatternMatrix[channel][order] = patternId; }
     }
 
-    inline const RowType& GetRowById(unsigned channel, unsigned patternId, unsigned row) const
-    {
-        return m_Patterns[channel][patternId][row];
+    // NumPatterns
+    if constexpr (m_StorageType == PatternStorageType::ORC) {
+        inline uint8_t GetNumPatterns() const { return m_NumPatterns; }
+        inline void SetNumPatterns(uint8_t numPatterns) { m_NumPatterns = numPatterns; }
+    } else if constexpr (m_StorageType == PatternStorageType::COR) {
+        inline uint8_t GetNumPatterns(unsigned channel) const { return m_NumPatterns[channel]; }
+        inline void SetNumPatterns(unsigned channel, uint8_t numPatterns) { m_NumPatterns[channel] = numPatterns; }
     }
 
-    inline const ChannelMetadataType& GetChannelMetadata(unsigned channel) const
-    {
-        return m_ChannelMetadata[channel];
+    // Pattern / PatternById
+    if constexpr (m_StorageType == PatternStorageType::ORC) {
+        inline PatternType GetPattern(unsigned order) const { return m_Patterns[GetPatternId(order)]; }
+        inline void SetPattern(unsigned order, PatternType&& pattern) { m_Patterns[GetPatternId(order)] = std::move(pattern); } // TODO: Deep copy?
+        inline PatternType GetPatternById(unsigned patternId) const { return m_Patterns[patternId]; }
+        inline void SetPatternById(unsigned patternId, PatternType&& pattern) { m_Patterns[patternId] = std::move(pattern); } // TODO: Deep copy?
+    } else if constexpr (m_StorageType == PatternStorageType::COR) {
+        inline PatternType GetPattern(unsigned channel, unsigned order) const { return m_Patterns[channel][GetPatternId(channel, order)]; }
+        inline void SetPattern(unsigned channel, unsigned order, PatternType&& pattern) { m_Patterns[channel][GetPatternId(channel, order)] = std::move(pattern); } // TODO: Deep copy?
+        inline PatternType GetPatternById(unsigned channel, unsigned patternId) const { return m_Patterns[channel][patternId]; }
+        inline void SetPatternById(unsigned channel, unsigned patternId, PatternType&& pattern) { m_Patterns[channel][patternId] = std::move(pattern); } // TODO: Deep copy?
     }
 
-    inline const PatternMetadataType& GetPatternMetadata(unsigned channel, unsigned pattern) const
-    {
-        return m_PatternMetadata[channel][pattern];
+    // Row / RowById
+    if constexpr (m_StorageType == PatternStorageType::ORC) {
+        inline const RowType& GetRow(unsigned channel, unsigned order, unsigned row) const { return GetPattern(order)[row][channel]; }
+        inline void SetRow(unsigned channel, unsigned order, unsigned row, const RowType& rowValue) { GetPattern(order)[row][channel] = rowValue; }
+        inline const RowType& GetRowById(unsigned channel, unsigned patternId, unsigned row) const { return GetPatternById(patternId)[row][channel]; }
+        inline void SetRowById(unsigned channel, unsigned patternId, unsigned row, const RowType& rowValue) { GetPatternById(patternId)[row][channel] = rowValue; }
+    } else if constexpr (m_StorageType == PatternStorageType::COR) {
+        inline const RowType& GetRow(unsigned channel, unsigned order, unsigned row) const { return GetPattern(channel, order)[row]; }
+        inline void SetRow(unsigned channel, unsigned order, unsigned row, const RowType& rowValue) { GetPattern(channel, order)[row] = rowValue; }
+        inline const RowType& GetRowById(unsigned channel, unsigned patternId, unsigned row) const { return GetPatternById(channel, patternId)[row]; }
+        inline void SetRowById(unsigned channel, unsigned patternId, unsigned row, const RowType& rowValue) { GetPatternById(channel, patternId)[row] = rowValue; }
     }
 
-    /////// SETTERS ///////
-
-    inline void SetPatternId(unsigned channel, unsigned order, uint8_t patternId) { m_PatternIds[channel][order] = patternId; }
-
-    inline void SetNumPatterns(unsigned channel, uint8_t numPatterns) { m_NumPatterns[channel] = numPatterns; }
-
-    // TODO: Deep copy?
-    inline void SetPattern(unsigned channel, unsigned order, PatternType&& pattern) { m_Patterns[channel][GetPatternId(channel, order)] = std::move(pattern); }
-
-    // TODO: Deep copy?
-    inline void GetPatternById(unsigned channel, unsigned patternId, PatternType&& pattern) { m_Patterns[channel][patternId] = std::move(pattern); }
-
-    inline void SetRow(unsigned channel, unsigned order, unsigned row, const RowType& rowValue)
-    {
-        m_Patterns[channel][m_PatternIds[channel][order]][row] = rowValue;
+    // PatternMetadata
+    if constexpr (m_StorageType == PatternStorageType::ORC) {
+        inline const PatternMetadataType& GetPatternMetadata(unsigned patternId) const { return m_PatternMetadata[patternId]; }
+        inline void SetPatternMetadata(unsigned patternId, const PatternMetadataType& patternMetadata) { m_PatternMetadata[patternId] = patternMetadata; }
+    } else if constexpr (m_StorageType == PatternStorageType::COR) {
+        inline const PatternMetadataType& GetPatternMetadata(unsigned channel, unsigned patternId) const { return m_PatternMetadata[channel][patternId]; }
+        inline void SetPatternMetadata(unsigned channel, unsigned patternId, const PatternMetadataType& patternMetadata) { m_PatternMetadata[channel][patternId] = patternMetadata; }
     }
 
-    inline void SetRowById(unsigned channel, unsigned patternId, unsigned row, const RowType& rowValue)
-    {
-        m_Patterns[channel][patternId][row] = rowValue;
-    }
-
-    inline void SetChannelMetadata(unsigned channel, const ChannelMetadataType& channelMetadata)
-    {
-        m_ChannelMetadata[channel] = channelMetadata;
-    }
-
-    inline void SetPatternMetadata(unsigned channel, unsigned pattern, const PatternMetadataType& patternMetadata)
-    {
-        m_PatternMetadata[channel][pattern] = patternMetadata;
-    }
+    /////// Other
 
     void CleanUp()
     {
-        if (!m_NumPatterns.empty())
-        {
-            for (unsigned channel = 0; channel < m_NumChannels; ++channel)
-            {
-                for (unsigned patternId = 0; patternId < m_NumPatterns[channel]; ++patternId)
-                {
-                    delete[] m_Patterns[channel][patternId];
-                    m_Patterns[channel][patternId] = nullptr;
-                }
-                delete[] m_Patterns[channel];
-                m_Patterns[channel] = nullptr;
-            }
-            m_Patterns.clear();
-        }
-
         m_NumChannels = 0;
         m_NumOrders = 0;
         m_NumRows = 0;
 
-        m_PatternIds.clear();
-        m_NumPatterns.clear();
         m_ChannelMetadata.clear();
-        m_PatternMetadata.clear();
+        m_GlobalData.reset();
     }
 
 private:
@@ -235,16 +368,11 @@ private:
     unsigned        m_NumOrders;    // Total orders (pattern matrix rows)
     unsigned        m_NumRows;      // Rows per pattern
 
-    // Pattern matrix
-    std::vector<std::vector<uint8_t>>   m_PatternIds;  // Stores patterns IDs for each order and channel in the pattern matrix
-    std::vector<uint8_t>                m_NumPatterns; // Patterns per channel
-
-    // Pattern info
-    std::vector<PatternType*>   m_Patterns; // [channel][pattern id]
-
     // Metadata (optional module-specific info)
     std::vector<ChannelMetadataType> m_ChannelMetadata; // [channel]
-    std::vector<std::vector<PatternMetadataType>> m_PatternMetadata; // [channel][pattern id]
+
+    // Wrapping this in a smart pointer avoids the "explicit specialization must precede its first use" error:
+    std::unique_ptr<GlobalDataType> m_GlobalData;   // Global information about a particular module file
 };
 
 } // namespace d2m

--- a/include/core/module.h
+++ b/include/core/module.h
@@ -43,8 +43,8 @@ protected:
     static const ModuleInfo& GetInfo();
 
 private:
-    static const ModuleInfo m_Info;
-    ModuleData<T> m_Data;
+    static const ModuleInfo m_Info;     // Info inherent to every module of type T
+    ModuleData<T> m_Data;               // Song information for a particular module file
 };
 
 

--- a/include/core/module.h
+++ b/include/core/module.h
@@ -26,6 +26,9 @@ public:
 
     inline const ModuleData<T>& GetData() const { return m_Data; }
 
+    std::string GetTitle() const override { return GetData().GlobalData().title; }
+    std::string GetAuthor() const override { return GetData().GlobalData().author; }
+
 protected:
 
     inline ModuleData<T>& GetData() { return m_Data; }

--- a/include/core/module.h
+++ b/include/core/module.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "module_base.h"
+#include "core/note.h"
 #include "conversion_options.h"
 #include "global_options.h"
 

--- a/include/core/module.h
+++ b/include/core/module.h
@@ -9,13 +9,14 @@
 #pragma once
 
 #include "module_base.h"
-#include "core/note.h"
+#include "data.h"
+#include "note.h"
 #include "conversion_options.h"
 #include "global_options.h"
 
 namespace d2m {
 
-// All module classes must inherit this using CRTP
+// All module classes must derive from this using CRTP
 template <class T, class O>
 class ModuleInterface : public ModuleBase
 {
@@ -23,7 +24,12 @@ public:
     friend class Registrar;
     using OptionsType = O;
 
+    inline const ModuleData<T>& GetData() const { return m_Data; }
+
 protected:
+
+    inline ModuleData<T>& GetData() { return m_Data; }
+
     ModuleType GetType() const override
     {
         return m_Info.GetType();
@@ -38,6 +44,7 @@ protected:
 
 private:
     static const ModuleInfo m_Info;
+    ModuleData<T> m_Data;
 };
 
 

--- a/include/core/module_base.h
+++ b/include/core/module_base.h
@@ -35,7 +35,7 @@ public:
     /*
      * Create a new module of the desired module type
      */
-    template <class T, class = std::enable_if_t<std::is_base_of<ModuleInterface<T, typename T::OptionsType>, T>{}>>
+    template <class T, class = std::enable_if_t<std::is_base_of_v<ModuleInterface<T, typename T::OptionsType>, T>>>
     static ModulePtr Create()
     {
         return ModulePtr(new T);
@@ -151,18 +151,21 @@ public:
     /*
      * Cast a Module pointer to a pointer of a derived type
      */
-    template <class T, class = std::enable_if_t<std::is_base_of<ModuleInterface<T, typename T::OptionsType>, T>{}>>
+    template <class T, class = std::enable_if_t<std::is_base_of_v<ModuleInterface<T, typename T::OptionsType>, T>>>
     const T* Cast() const
     {
         return static_cast<const T*>(this);
     }
 
     /*
-     * Get the name of the module
-     * Module classes must implement this
+     * Get the title of the module
      */
-    virtual std::string GetName() const = 0;
+    virtual std::string GetTitle() const = 0;
 
+    /*
+     * Get the author of the module
+     */
+    virtual std::string GetAuthor() const = 0;
 
     ////////////////////////////////////////////////////////
     // Methods for getting static info about module type  //

--- a/include/core/note.h
+++ b/include/core/note.h
@@ -9,6 +9,7 @@
 
 #include <variant>
 #include <cstdint>
+#include <cassert>
 
 namespace d2m {
 

--- a/include/core/note.h
+++ b/include/core/note.h
@@ -1,0 +1,101 @@
+/*
+    note.h
+    Written by Dalton Messmer <messmer.dalton@gmail.com>.
+
+    Defines a data structure for storing notes + helper functions.
+*/
+
+#pragma once
+
+#include <variant>
+#include <cstdint>
+
+namespace d2m {
+
+enum class NotePitch : uint16_t
+{
+    C=0,
+    CS,
+    D,
+    DS,
+    E,
+    F,
+    FS,
+    G,
+    GS,
+    A,
+    AS,
+    B
+};
+
+namespace NoteTypes
+{
+    enum { EmptyType, NoteType, OffType }; // The order is important
+    struct Empty {};
+    struct Note
+    {
+        NotePitch pitch;
+        uint16_t octave;
+
+        //Note(NotePitch pitch, uint16_t octave) : pitch(pitch), octave(octave) {}
+
+        bool operator>(const Note& rhs) const
+        {
+            return (this->octave << 4) + static_cast<uint16_t>(this->pitch) > (rhs.octave << 4) + static_cast<uint16_t>(rhs.pitch);
+        }
+
+        bool operator>=(const Note& rhs) const
+        {
+            return (this->octave << 4) + static_cast<uint16_t>(this->pitch) >= (rhs.octave << 4) + static_cast<uint16_t>(rhs.pitch);
+        }
+
+        bool operator<(const Note& rhs) const
+        {
+            return (this->octave << 4) + static_cast<uint16_t>(this->pitch) < (rhs.octave << 4) + static_cast<uint16_t>(rhs.pitch);
+        }
+
+        bool operator<=(const Note& rhs) const
+        {
+            return (this->octave << 4) + static_cast<uint16_t>(this->pitch) <= (rhs.octave << 4) + static_cast<uint16_t>(rhs.pitch);
+        }
+
+        bool operator==(const Note& rhs) const
+        {
+            return this->octave == rhs.octave && this->pitch == rhs.pitch;
+        }
+
+        bool operator!=(const Note& rhs) const
+        {
+            return this->octave != rhs.octave || this->pitch != rhs.pitch;
+        }
+    };
+    struct Off {};
+};
+
+using NoteSlot = std::variant<NoteTypes::Empty, NoteTypes::Note, NoteTypes::Off>;
+using Note = NoteTypes::Note; // For convenience
+
+inline bool NoteIsEmpty(const NoteSlot& note) { return note.index() == NoteTypes::EmptyType; }
+inline bool NoteHasPitch(const NoteSlot& note) { return note.index() == NoteTypes::NoteType; }
+inline bool NoteIsOff(const NoteSlot& note) { return note.index() == NoteTypes::OffType; }
+inline Note& GetNote(NoteSlot& note)
+{
+    assert(NoteHasPitch(note) && "NoteSlot variant must be using the Note alternative");
+    return std::get<Note>(note);
+}
+
+inline const Note& GetNote(const NoteSlot& note)
+{
+    assert(NoteHasPitch(note) && "NoteSlot variant must be using the Note alternative");
+    return std::get<Note>(note);
+}
+
+inline int GetNoteRange(const Note& low, const Note& high)
+{
+    // Returns range in semitones. Assumes high >= low.
+    // Range is inclusive on both ends.
+
+    return (high.octave - low.octave) * 12 + (static_cast<uint16_t>(high.pitch) - static_cast<uint16_t>(low.pitch)) + 1;
+}
+
+} // namespace d2m

--- a/include/core/options.h
+++ b/include/core/options.h
@@ -52,7 +52,7 @@ public:
     OptionDefinition() : m_OptionType(OPTION), m_Id(-1), m_ValueType(Type::BOOL), m_Name(""), m_ShortName('\0'), m_DefaultValue(false) {}
 
     // OptionDefinition without accepted values; The value can be anything allowed by the variant
-    template<typename T, typename = std::enable_if_t<std::is_integral<T>{} || (std::is_enum<T>{} && std::is_convertible<std::underlying_type_t<T>, int>{})>>
+    template<typename T, typename = std::enable_if_t<std::is_integral<T>{} || (std::is_enum_v<T> && std::is_convertible_v<std::underlying_type_t<T>, int>)>>
     OptionDefinition(OptionType type, T id, const std::string& name, char shortName, const value_t& defaultValue, const std::string& description)
         : m_OptionType(type), m_Id(static_cast<int>(id)), m_Name(name), m_ShortName(shortName), m_DefaultValue(defaultValue), m_AcceptedValues({}), m_AcceptedValuesOrdered({}), m_Description(description)
     {
@@ -69,8 +69,8 @@ public:
 
     // OptionDefinition with accepted values; Ensures that defaultValue and acceptedValues are the same type and are a valid variant alternative
     template <typename T, typename U, 
-        typename = std::enable_if_t<std::is_constructible<value_t, U>{} && /* U must be a valid variant alternative */
-        (std::is_integral<T>{} || (std::is_enum<T>{} && std::is_convertible<std::underlying_type_t<T>, int>{}))>> /* T must be int or enum class with int underlying type */
+        typename = std::enable_if_t<std::is_constructible_v<value_t, U> && /* U must be a valid variant alternative */
+        (std::is_integral_v<T> || (std::is_enum_v<T> && std::is_convertible_v<std::underlying_type_t<T>, int>))>> /* T must be int or enum class with int underlying type */
     OptionDefinition(OptionType type, T id, const std::string& name, char shortName, const U& defaultValue, const std::initializer_list<U>& acceptedValues, const std::string& description)
         : m_OptionType(type), m_Id(static_cast<int>(id)), m_Name(name), m_ShortName(shortName), m_DefaultValue(defaultValue), m_Description(description)
     {
@@ -110,13 +110,13 @@ public:
     }
 
     // Allows the use of string literals, which are converted to std::string
-    template<typename T, typename = std::enable_if_t<std::is_integral<T>{} || (std::is_enum<T>{} && std::is_convertible<std::underlying_type_t<T>, int>{})>>
+    template<typename T, typename = std::enable_if_t<std::is_integral_v<T> || (std::is_enum_v<T> && std::is_convertible_v<std::underlying_type_t<T>, int>)>>
     OptionDefinition(OptionType type, T id, const std::string& name, char shortName, const char* defaultValue, const std::initializer_list<std::string>& acceptedValues, const std::string& description)
         : OptionDefinition(type, id, name, shortName, std::string(defaultValue), acceptedValues, description) {}
 
     // Allows custom accepted values text which is used when printing help for this option. m_AcceptedValues is empty.
-    template<typename T, typename U, typename = std::enable_if_t<std::is_constructible<value_t, U>{} && /* U must be a valid variant alternative */
-    (std::is_integral<T>{} || (std::is_enum<T>{} && std::is_convertible<std::underlying_type_t<T>, int>{}))>> /* T must be int or enum class with int underlying type */
+    template<typename T, typename U, typename = std::enable_if_t<std::is_constructible_v<value_t, U> && /* U must be a valid variant alternative */
+    (std::is_integral_v<T> || (std::is_enum_v<T> && std::is_convertible_v<std::underlying_type_t<T>, int>))>> /* T must be int or enum class with int underlying type */
     OptionDefinition(OptionType type, T id, const std::string& name, char shortName, const U& defaultValue, const char* customAcceptedValuesText, const std::string& description)
         : OptionDefinition(type, id, name, shortName, defaultValue, description)
     {
@@ -287,13 +287,13 @@ public:
     const Option& GetOption(int id) const { return m_OptionsMap.at(id); }
     Option& GetOption(int id) { return m_OptionsMap[id]; }
 
-    template<typename T, class = std::enable_if_t<std::is_enum<T>{} && std::is_convertible<std::underlying_type_t<T>, int>{}>>
+    template<typename T, class = std::enable_if_t<std::is_enum_v<T> && std::is_convertible_v<std::underlying_type_t<T>, int>>>
     const Option& GetOption(T id) const
     {
         return GetOption(static_cast<int>(id));
     }
 
-    template<typename T, class = std::enable_if_t<std::is_enum<T>{} && std::is_convertible<std::underlying_type_t<T>, int>{}>>
+    template<typename T, class = std::enable_if_t<std::is_enum_v<T> && std::is_convertible_v<std::underlying_type_t<T>, int>>>
     Option& GetOption(T id)
     {
         return GetOption(static_cast<int>(id));

--- a/include/core/registrar.h
+++ b/include/core/registrar.h
@@ -53,7 +53,7 @@ public:
 
     ModuleInfo() = default;
 
-    template<class T, class = std::enable_if_t<std::is_base_of<ModuleInterface<T, typename T::OptionsType>, T>{}>>
+    template<class T, class = std::enable_if_t<std::is_base_of_v<ModuleInterface<T, typename T::OptionsType>, T>>>
     static ModuleInfo Create(ModuleType moduleType, std::string friendlyName, std::string fileExtension)
     {
         return ModuleInfo(
@@ -89,13 +89,13 @@ public:
 
     ConversionOptionsInfo() = default;
 
-    template<class T, class = std::enable_if_t<std::is_base_of<ConversionOptionsInterface<T>, T>{}>>
+    template<class T, class = std::enable_if_t<std::is_base_of_v<ConversionOptionsInterface<T>, T>>>
     static ConversionOptionsInfo Create(ModuleType moduleType, std::shared_ptr<OptionDefinitionCollection> definitions)
     {
         return ConversionOptionsInfo([](){ return std::make_shared<T>(); }, moduleType, definitions);
     }
 
-    template<class T, class = std::enable_if_t<std::is_base_of<ConversionOptionsInterface<T>, T>{}>>
+    template<class T, class = std::enable_if_t<std::is_base_of_v<ConversionOptionsInterface<T>, T>>>
     static ConversionOptionsInfo Create(ModuleType moduleType)
     {
         return ConversionOptionsInfo([](){ return std::make_shared<T>(); }, moduleType, std::make_shared<OptionDefinitionCollection>());
@@ -137,7 +137,7 @@ private:
      * Registers a module in the registration maps
      * TODO: Need to also check whether the ConversionOptionsStatic<T> specialization exists?
      */
-    template <class T, class = std::enable_if_t<std::is_base_of<ModuleInterface<T, typename T::OptionsType>, T>{}>>
+    template <class T, class = std::enable_if_t<std::is_base_of_v<ModuleInterface<T, typename T::OptionsType>, T>>>
     static void Register();
 
 private:

--- a/include/core/status.h
+++ b/include/core/status.h
@@ -82,7 +82,7 @@ public: // Should this be private once DMF gets its own DMFException class?
     ModuleException& operator=(ModuleException& other) = default;
 
     // Construct using an enum for an error code
-    template <class T, class = std::enable_if_t<std::is_enum<T>{} && std::is_convertible<std::underlying_type_t<T>, int>{}>>
+    template <class T, class = std::enable_if_t<std::is_enum_v<T> && std::is_convertible_v<std::underlying_type_t<T>, int>>>
     ModuleException(Category category, T errorCode, const std::string& errorMessage = "")
         : ModuleException(category, static_cast<int>(errorCode), errorMessage) {}
 

--- a/include/core/status.h
+++ b/include/core/status.h
@@ -83,11 +83,11 @@ public: // Should this be private once DMF gets its own DMFException class?
 
     // Construct using an enum for an error code
     template <class T, class = std::enable_if_t<std::is_enum<T>{} && std::is_convertible<std::underlying_type_t<T>, int>{}>>
-    ModuleException(Category category, T errorCode, const std::string errorMessage = "")
+    ModuleException(Category category, T errorCode, const std::string& errorMessage = "")
         : ModuleException(category, static_cast<int>(errorCode), errorMessage) {}
 
     // Construct using an integer for an error code
-    ModuleException(Category category, int errorCode, const std::string errorMessage = "")
+    ModuleException(Category category, int errorCode, const std::string& errorMessage = "")
     {
         m_ErrorCode = errorCode;
 

--- a/include/modules/dmf.h
+++ b/include/modules/dmf.h
@@ -17,7 +17,11 @@
 namespace d2m {
 
 // Declare module
-MODULE_DECLARE(DMF, DMFConversionOptions)
+
+class DMF;
+
+template<>
+struct ModuleGlobalData<DMF> : public ModuleGlobalDataGeneric<DataStorageType::COR> {};
 
 namespace dmf {
     struct Effect
@@ -47,6 +51,8 @@ struct PatternMetadata<DMF>
 {
     std::string name;
 };
+
+MODULE_DECLARE(DMF, DMFConversionOptions)
 
 namespace dmf {
 
@@ -105,10 +111,6 @@ struct System
 
 struct VisualInfo
 {
-    uint8_t songNameLength;
-    std::string songName;
-    uint8_t songAuthorLength;
-    std::string songAuthor;
     uint8_t highlightAPatterns;
     uint8_t highlightBPatterns;
 };
@@ -254,8 +256,6 @@ public:
     DMF();
     ~DMF();
     void CleanUp();
-
-    std::string GetName() const override { return m_VisualInfo.songName; }
 
     ////////////
 

--- a/include/modules/dmf.h
+++ b/include/modules/dmf.h
@@ -24,112 +24,38 @@ namespace dmf {
 // Deflemask allows four effects columns per channel regardless of the system 
 #define DMF_MAX_EFFECTS_COLUMN_COUNT 4
 
-enum class NotePitch
-{
-    Empty=0,
-    C=0,
-    CS=1,
-    D=2,
-    DS=3,
-    E=4,
-    F=5,
-    FS=6,
-    G=7,
-    GS=8,
-    A=9,
-    AS=10,
-    B=11,
-    C_Alt=12,
-    Off=100
-};
-
 static const int DMFNoInstrument = -1;
 static const int DMFNoVolume = -1;
 static const int DMFVolumeMax = 15; /* ??? */
 
 // Deflemask effects shared by all systems:
-enum class EffectCode
+namespace EffectCode
 {
-    NoEffect=-1, NoEffectVal=-1,
-    Arp=0x0, PortUp=0x1, PortDown=0x2, Port2Note=0x3, Vibrato=0x4, Port2NoteVolSlide=0x5, VibratoVolSlide=0x6,
-    Tremolo=0x7, Panning=0x8, SetSpeedVal1=0x9, VolSlide=0xA, PosJump=0xB, Retrig=0xC, PatBreak=0xD,
-    ArpTickSpeed=0xE0, NoteSlideUp=0xE1, NoteSlideDown=0xE2, SetVibratoMode=0xE3, SetFineVibratoDepth=0xE4,
-    SetFinetune=0xE5, SetSamplesBank=0xEB, NoteCut=0xEC, NoteDelay=0xED, SyncSignal=0xEE, SetGlobalFinetune=0xEF,
-    SetSpeedVal2=0xF
-};
+    enum
+    {
+        NoEffect=-1, NoEffectVal=-1,
+        Arp=0x0, PortUp=0x1, PortDown=0x2, Port2Note=0x3, Vibrato=0x4, Port2NoteVolSlide=0x5, VibratoVolSlide=0x6,
+        Tremolo=0x7, Panning=0x8, SetSpeedVal1=0x9, VolSlide=0xA, PosJump=0xB, Retrig=0xC, PatBreak=0xD,
+        ArpTickSpeed=0xE0, NoteSlideUp=0xE1, NoteSlideDown=0xE2, SetVibratoMode=0xE3, SetFineVibratoDepth=0xE4,
+        SetFinetune=0xE5, SetSamplesBank=0xEB, NoteCut=0xEC, NoteDelay=0xED, SyncSignal=0xEE, SetGlobalFinetune=0xEF,
+        SetSpeedVal2=0xF
+    };
+}
 
 // Deflemask effects exclusive to the Game Boy system:
-enum class GameBoyEffectCode
+namespace GameBoyEffectCode
 {
-    SetWave=0x10,
-    SetNoisePolyCounterMode=0x11,
-    SetDutyCycle=0x12,
-    SetSweepTimeShift=0x13,
-    SetSweepDir=0x14
-};
+    enum
+    {
+        SetWave=0x10,
+        SetNoisePolyCounterMode=0x11,
+        SetDutyCycle=0x12,
+        SetSweepTimeShift=0x13,
+        SetSweepDir=0x14
+    };
+}
 
 // To do: Add enums for effects exclusive to the rest of Deflemask's systems.
-
-struct Note
-{
-    uint16_t pitch;
-    uint16_t octave;
-
-    Note() = default;
-    Note(uint16_t p, uint16_t o)
-        : pitch(p), octave(o)
-    {}
-
-    Note(NotePitch p, uint16_t o)
-        : pitch((uint16_t)p), octave(o)
-    {}
-
-    inline bool HasPitch() const
-    {
-        if (pitch == 0 && octave == 0)
-            return false; // Empty note
-        return pitch >= 0 && pitch <= 12;
-        // Contrary to specs, pitch == 0 means C-. I'm not sure if pitch == 12 is also used for C-.
-    }
-
-    inline bool IsOff() const
-    {
-        return pitch == (int)NotePitch::Off;
-    }
-
-    inline bool IsEmpty() const
-    {
-        return pitch == 0 && octave == 0;
-    }
-
-    bool operator==(const Note& rhs) const;
-    bool operator!=(const Note& rhs) const;
-    bool operator>(const Note& rhs) const;
-    bool operator<(const Note& rhs) const;
-    bool operator>=(const Note& rhs) const;
-    bool operator<=(const Note& rhs) const;
-};
-
-int GetNoteRange(const Note& low, const Note& high);
-
-// Comparison operators for enums
-template <typename T, typename U,
-    class = typename std::enable_if<std::is_enum<U>{} &&
-    std::is_same<std::underlying_type_t<U>, int>{} &&
-    std::is_integral<T>{}>>
-bool operator==(T lhs, const U& rhs)
-{
-    return lhs == static_cast<T>(rhs);
-}
-
-template <typename T, typename U,
-    class = typename std::enable_if<std::is_enum<U>{} &&
-    std::is_same<std::underlying_type_t<U>, int>{} &&
-    std::is_integral<T>{}>>
-bool operator!=(T lhs, const U& rhs)
-{
-    return lhs != static_cast<T>(rhs);
-}
 
 struct System
 {
@@ -268,18 +194,20 @@ struct Effect
 
 struct ChannelRow
 {
-    Note note;
+    NoteSlot note;
     int16_t volume;
     Effect effect[DMF_MAX_EFFECTS_COLUMN_COUNT];
     int16_t instrument;
 };
 
 // Deflemask Game Boy channels
-enum class GameBoyChannel
+namespace GameBoyChannel
 {
-    SQW1=0, SQW2=1, WAVE=2, NOISE=3
-};
-
+    enum
+    {
+        SQW1=0, SQW2=1, WAVE=2, NOISE=3
+    };
+}
 
 } // namespace dmf
 
@@ -326,10 +254,10 @@ public:
      * In spite of what the Deflemask manual says, portamento effects are automatically turned off if they
      * stay on long enough without a new note being played. These methods help handle those edge cases.
      */
-    int GetRowsUntilPortUpAutoOff(const dmf::Note& note, int portUpParam) const;
-    static int GetRowsUntilPortUpAutoOff(unsigned ticksPerRowPair, const dmf::Note& note, int portUpParam);
-    int GetRowsUntilPortDownAutoOff(const dmf::Note& note, int portDownParam) const;
-    static int GetRowsUntilPortDownAutoOff(unsigned ticksPerRowPair, const dmf::Note& note, int portDownParam);
+    int GetRowsUntilPortUpAutoOff(const NoteSlot& note, int portUpParam) const;
+    static int GetRowsUntilPortUpAutoOff(unsigned ticksPerRowPair, const NoteSlot& note, int portUpParam);
+    int GetRowsUntilPortDownAutoOff(const NoteSlot& note, int portDownParam) const;
+    static int GetRowsUntilPortDownAutoOff(unsigned ticksPerRowPair, const NoteSlot& note, int portDownParam);
 
     inline unsigned GetTicksPerRowPair() const
     {

--- a/include/modules/dmf.h
+++ b/include/modules/dmf.h
@@ -19,8 +19,7 @@ namespace d2m {
 // Declare module
 MODULE_DECLARE(DMF, DMFConversionOptions)
 
-namespace dmf
-{
+namespace dmf {
     struct Effect
     {
         int16_t code;
@@ -33,7 +32,7 @@ struct Row<DMF>
 {
     NoteSlot note;
     int16_t volume;
-    dmf::Effect effect[4];
+    dmf::Effect effect[4]; // Deflemask allows four effects columns per channel regardless of the system
     int16_t instrument;
 };
 
@@ -50,9 +49,6 @@ struct PatternMetadata<DMF>
 };
 
 namespace dmf {
-
-// Deflemask allows four effects columns per channel regardless of the system 
-#define DMF_MAX_EFFECTS_COLUMN_COUNT 4
 
 static const int DMFNoInstrument = -1;
 static const int DMFNoVolume = -1;
@@ -106,6 +102,7 @@ struct System
         : type(type), id(id), name(name), channels(channels)
     {}
 };
+
 struct VisualInfo
 {
     uint8_t songNameLength;

--- a/include/modules/mod.h
+++ b/include/modules/mod.h
@@ -357,12 +357,12 @@ private:
     void DMFConvertSampleData(const DMF& dmf, const SampleMap& sampleMap);
 
     void DMFConvertPatterns(const DMF& dmf, const SampleMap& sampleMap);
-    mod::PriorityEffectsMap DMFConvertEffects(const dmf::ChannelRow& pat, mod::State& state);
-    mod::PriorityEffectsMap DMFConvertEffects_NoiseChannel(const dmf::ChannelRow& pat);
+    mod::PriorityEffectsMap DMFConvertEffects(const Row<DMF>& row, mod::State& state);
+    mod::PriorityEffectsMap DMFConvertEffects_NoiseChannel(const Row<DMF>& row);
     void DMFUpdateStatePre(const DMF& dmf, mod::State& state, const mod::PriorityEffectsMap& modEffects);
-    void DMFGetAdditionalEffects(const DMF& dmf, mod::State& state, const dmf::ChannelRow& pat, mod::PriorityEffectsMap& modEffects);
+    void DMFGetAdditionalEffects(const DMF& dmf, mod::State& state, const Row<DMF>& row, mod::PriorityEffectsMap& modEffects);
     //void DMFUpdateStatePost(const DMF& dmf, mod::State& state, const mod::PriorityEffectsMap& modEffects);
-    Note DMFConvertNote(mod::State& state, const dmf::ChannelRow& pat, const SampleMap& sampleMap, mod::PriorityEffectsMap& modEffects, mod::mod_sample_id_t& sampleId, uint16_t& period);
+    Note DMFConvertNote(mod::State& state, const Row<DMF>& row, const SampleMap& sampleMap, mod::PriorityEffectsMap& modEffects, mod::mod_sample_id_t& sampleId, uint16_t& period);
     mod::ChannelRow DMFApplyNoteAndEffect(mod::State& state, const mod::PriorityEffectsMap& modEffects, mod::mod_sample_id_t modSampleId, uint16_t period);
 
     void DMFConvertInitialBPM(const DMF& dmf, unsigned& tempo, unsigned& speed);

--- a/include/modules/mod.h
+++ b/include/modules/mod.h
@@ -18,7 +18,28 @@
 namespace d2m {
 
 // Declare module
+
+class MOD;
+
+template<>
+struct ModuleGlobalData<MOD> : public ModuleGlobalDataGeneric<PatternStorageType::ORC>
+{
+    // In the future, we'll be able to detect when a MOD module
+    // was created with dmf2mod, which will help when converting
+    // from MOD to another module type.
+    bool madeWithDmf2mod;
+};
+
 MODULE_DECLARE(MOD, MODConversionOptions)
+
+template<>
+struct Row<MOD>
+{
+    uint8_t SampleNumber;
+    uint16_t SamplePeriod;
+    unsigned EffectCode;
+    unsigned EffectValue;
+};
 
 namespace mod {
 
@@ -68,6 +89,7 @@ enum EffectPriority
     EffectPriorityUnsupportedEffect /* Must be the last enum value */
 };
 
+/*
 struct ChannelRow
 {
     uint8_t SampleNumber;
@@ -75,6 +97,7 @@ struct ChannelRow
     unsigned EffectCode;
     unsigned EffectValue;
 };
+*/
 
 using dmf_sample_id_t = int;
 using mod_sample_id_t = int;
@@ -188,7 +211,7 @@ struct State
     ChannelState channel[4];
     ChannelState channelCopy[4];
 
-    ChannelRow channelRows[4];
+    Row<MOD> channelRows[4];
 
     State()
     {
@@ -322,7 +345,8 @@ public:
         Success=0,
         NotGameBoy,
         TooManyPatternMatrixRows,
-        Over64RowPattern
+        Over64RowPattern,
+        WrongChannelCount
     };
 
     enum class ConvertWarning
@@ -363,7 +387,7 @@ private:
     void DMFGetAdditionalEffects(const DMF& dmf, mod::State& state, const Row<DMF>& row, mod::PriorityEffectsMap& modEffects);
     //void DMFUpdateStatePost(const DMF& dmf, mod::State& state, const mod::PriorityEffectsMap& modEffects);
     Note DMFConvertNote(mod::State& state, const Row<DMF>& row, const SampleMap& sampleMap, mod::PriorityEffectsMap& modEffects, mod::mod_sample_id_t& sampleId, uint16_t& period);
-    mod::ChannelRow DMFApplyNoteAndEffect(mod::State& state, const mod::PriorityEffectsMap& modEffects, mod::mod_sample_id_t modSampleId, uint16_t period);
+    Row<MOD> DMFApplyNoteAndEffect(mod::State& state, const mod::PriorityEffectsMap& modEffects, mod::mod_sample_id_t modSampleId, uint16_t period);
 
     void DMFConvertInitialBPM(const DMF& dmf, unsigned& tempo, unsigned& speed);
 
@@ -375,6 +399,7 @@ private:
     void ExportSampleData(std::ofstream& fout) const;
 
     // Other:
+    /*
     inline mod::ChannelRow& GetChannelRow(unsigned pattern, unsigned row, unsigned channel)
     {
         return m_Patterns[pattern][(row << m_NumberOfChannelsPowOfTwo) + channel];
@@ -384,6 +409,7 @@ private:
     {
         m_Patterns.at(pattern).at((row << m_NumberOfChannelsPowOfTwo) + channel) = channelRow;
     }
+    */
 
 private:
     //////////// Temporaries used during DMF-->MOD conversion
@@ -392,10 +418,10 @@ private:
     //////////// MOD file info
     std::string m_ModuleName;
     int8_t m_TotalMODSamples;
-    unsigned m_NumberOfChannels;
-    unsigned char m_NumberOfChannelsPowOfTwo; // For efficiency. 2^m_NumberOfChannelsPowOfTwo = m_NumberOfChannels.
-    unsigned m_NumberOfRowsInPatternMatrix;
-    std::vector<std::vector<mod::ChannelRow>> m_Patterns; // Per pattern: Vector of channel rows that together contain data for entire pattern
+    ///unsigned m_NumberOfChannels;
+    //unsigned char m_NumberOfChannelsPowOfTwo; // For efficiency. 2^m_NumberOfChannelsPowOfTwo = m_NumberOfChannels.
+    ///unsigned m_NumberOfRowsInPatternMatrix;
+    //std::vector<std::vector<mod::ChannelRow>> m_Patterns; // Per pattern: Vector of channel rows that together contain data for entire module
     std::map<mod::mod_sample_id_t, mod::Sample> m_Samples;
 };
 

--- a/include/utils/hash.h
+++ b/include/utils/hash.h
@@ -1,0 +1,21 @@
+/*
+    hash.h
+    Written by Dalton Messmer <messmer.dalton@gmail.com>.
+
+    Custom hash functions
+*/
+
+#pragma once
+
+#include <cstddef>
+#include <utility>
+#include <functional>
+
+struct PairHash
+{
+    template<class T1, class T2>
+    size_t operator()(std::pair<T1, T2> const &pair) const
+    {
+        return std::hash<T1>()(pair.first) ^ std::hash<T2>()(pair.second);
+    }
+};

--- a/src/console/console.cpp
+++ b/src/console/console.cpp
@@ -126,7 +126,7 @@ OperationType ParseArgs(std::vector<std::string>& args, InputOutput& inputOutput
     inputOutputInfo.OutputFile = "";
     inputOutputInfo.OutputType = ModuleType::NONE;
 
-    const int argCount = args.size();
+    const size_t argCount = args.size();
 
     if (argCount == 1)
     {

--- a/src/modules/dmf.cpp
+++ b/src/modules/dmf.cpp
@@ -136,6 +136,8 @@ void DMF::CleanUp()
         delete[] m_PCMSamples;
         m_PCMSamples = nullptr;
     }
+
+    GetData().CleanUp();
 }
 
 void DMF::ImportRaw(const std::string& filename)
@@ -756,7 +758,7 @@ Row<DMF> DMF::LoadPatternRow(zstr::ifstream& fin, uint8_t effectsColumnsCount)
     }
 
     // Initialize the rest to zero
-    for (int col = effectsColumnsCount; col < DMF_MAX_EFFECTS_COLUMN_COUNT; ++col)
+    for (int col = effectsColumnsCount; col < 4; ++col) // Max total of 4 effects columns in Deflemask
     {
         row.effect[col] = {(int16_t)EffectCode::NoEffect, (int16_t)EffectCode::NoEffectVal};
     }

--- a/src/modules/mod.cpp
+++ b/src/modules/mod.cpp
@@ -1271,7 +1271,7 @@ void MOD::DMFConvertInitialBPM(const DMF& dmf, unsigned& tempo, unsigned& speed)
 
     if (GetOptions()->GetTempoType() == MODConversionOptions::TempoType::EffectCompatibility)
     {
-        tempo = desiredBPM * 2;
+        tempo = static_cast<unsigned>(desiredBPM * 2);
         speed = 6;
 
         if (tempo > 255)


### PR DESCRIPTION
Module data refactoring for issue #6 

A new class template called ModuleData is used to store all the song data for a module.
The underlying data structure used to store a module can be customized to make it more closely resemble the arrangement of the data inside the module format and make nested for-loops over the module data more cache-friendly. COR (Channel>Order>Row) and ORC (Order>Row>Channel) storage types have been implemented.

Modules can now define additional metadata associated with particular patterns or channels, or data stored globally.
In DMF, effect columns per channel and pattern names are now stored in channel metadata and pattern metadata respectively.
For both DMF and MOD, the module title, author name, and storage type are now stored in the global data. I may move the title and author information to ModuleBase later.

In MOD, the name of the 1st sample is now replaced with the author's name.