### PR TITLE
StreamReader utility

### DIFF
--- a/include/modules/dmf.h
+++ b/include/modules/dmf.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "core/module.h"
+#include "utils/stream_reader.h"
 #include <zstr/zstr.hpp>
 
 #include <string>
@@ -290,17 +291,19 @@ private:
     void ExportRaw(const std::string& filename) override;
     void ConvertRaw(const Module* input) override;
 
+    using Reader = StreamReader<zstr::ifstream, Endianness::Little>;
+
     dmf::System GetSystem(uint8_t systemByte) const;
-    void LoadVisualInfo(zstr::ifstream& fin);
-    void LoadModuleInfo(zstr::ifstream& fin);
-    void LoadPatternMatrixValues(zstr::ifstream& fin);
-    void LoadInstrumentsData(zstr::ifstream& fin);
-    dmf::Instrument LoadInstrument(zstr::ifstream& fin, SystemType systemType);
-    void LoadWavetablesData(zstr::ifstream& fin);
-    void LoadPatternsData(zstr::ifstream& fin);
-    Row<DMF> LoadPatternRow(zstr::ifstream& fin, uint8_t effectsColumnsCount);
-    void LoadPCMSamplesData(zstr::ifstream& fin);
-    dmf::PCMSample LoadPCMSample(zstr::ifstream& fin);
+    void LoadVisualInfo(Reader& fin);
+    void LoadModuleInfo(Reader& fin);
+    void LoadPatternMatrixValues(Reader& fin);
+    void LoadInstrumentsData(Reader& fin);
+    dmf::Instrument LoadInstrument(Reader& fin, SystemType systemType);
+    void LoadWavetablesData(Reader& fin);
+    void LoadPatternsData(Reader& fin);
+    Row<DMF> LoadPatternRow(Reader& fin, uint8_t effectsColumnsCount);
+    void LoadPCMSamplesData(Reader& fin);
+    dmf::PCMSample LoadPCMSample(Reader& fin);
 
 private:
     uint8_t         m_DMFFileVersion;

--- a/include/utils/stream_reader.h
+++ b/include/utils/stream_reader.h
@@ -1,0 +1,174 @@
+/*
+    stream_reader.h
+    Written by Dalton Messmer <messmer.dalton@gmail.com>.
+
+    Defines a header-only wrapper for std::istream and derived classes
+    which provides convenient methods for reading strings and integers
+*/
+
+#pragma once
+
+#include <istream>
+#include <memory>
+#include <type_traits>
+#include <string>
+#include <vector>
+
+namespace d2m {
+
+namespace detail
+{
+    template<int N>
+    struct LoopUnroller
+    {
+        template<typename Operation>
+        inline void operator()(Operation& op) { op(); LoopUnroller<N-1>{}(op); }
+    };
+
+    template<>
+    struct LoopUnroller<0>
+    {
+        template<typename Operation>
+        inline void operator()(Operation& op) {}
+    };
+}
+
+enum class Endianness { Unspecified, Little, Big };
+
+/*
+    Wrapper for std::istream and derived classes which provides
+    convenient methods for reading strings and integers
+*/
+template <class IStream, Endianness GlobalEndian = Endianness::Unspecified, class = std::enable_if_t<std::is_base_of_v<std::basic_istream<char>, IStream>>>
+class StreamReader
+{
+private:
+    IStream m_Stream;
+
+    template <size_t Integer>
+    static inline constexpr bool is_power_of_two = ((Integer > 0) && (Integer & (Integer - 1)) == 0);
+
+    template<typename T, size_t Size>
+    struct LittleEndianReadOperator
+    {
+        static constexpr size_t ShiftAmount = (Size - 1) * 8;
+        static_assert(Size > 0);
+
+        inline void operator()()
+        {
+            value >>= 8;
+            value |= static_cast<T>(m_Stream.get()) << ShiftAmount;
+        }
+        IStream& m_Stream;
+        T value{};
+    };
+
+    template<typename T>
+    struct BigEndianReadOperator
+    {
+        inline void operator()()
+        {
+            value <<= 8;
+            value |= static_cast<T>(m_Stream.get());
+        }
+        IStream& m_Stream;
+        T value{};
+    };
+
+    template<typename T, size_t Size, typename = std::enable_if_t<std::is_integral_v<T> && is_power_of_two<sizeof(T)>>>
+    inline T ReadIntLittleEndian()
+    {
+        static_assert(Size <= sizeof(T), "Explicitly specified template parameter 'Size' must be <= sizeof(T)");
+        LittleEndianReadOperator<T, Size> oper{stream()};
+        detail::LoopUnroller<Size>{}(oper);
+
+        if constexpr (std::is_signed_v<T> && Size < sizeof(T))
+        {
+            struct SignExtender { T value : Size * 8; };
+            return SignExtender{oper.value}.value;
+        }
+        else
+        {
+            return oper.value;
+        }
+    }
+
+    template<typename T, size_t Size, typename = std::enable_if_t<std::is_integral_v<T> && is_power_of_two<sizeof(T)>>>
+    inline T ReadIntBigEndian()
+    {
+        static_assert(Size <= sizeof(T), "Explicitly specified template parameter 'Size' must be <= sizeof(T)");
+        BigEndianReadOperator<T> oper{stream()};
+        detail::LoopUnroller<Size>{}(oper);
+
+        if constexpr (std::is_signed_v<T> && Size < sizeof(T))
+        {
+            struct SignExtender { T value : Size * 8; };
+            return SignExtender{oper.value}.value;
+        }
+        else
+        {
+            return oper.value;
+        }
+    }
+
+public:
+
+    StreamReader() : m_Stream{} {}
+
+    // StreamReader constructs and owns the istream object
+    template <typename... Args>
+    StreamReader(Args&&... args) : m_Stream{std::forward<Args>(args)...} {}
+
+    StreamReader(const StreamReader&) = delete;
+    StreamReader(StreamReader&&) = delete;
+    StreamReader& operator=(const StreamReader&) = delete;
+    StreamReader& operator=(StreamReader&&) = delete;
+
+    const IStream& stream() const { return m_Stream; }
+    IStream& stream() { return m_Stream; }
+
+    std::string ReadStr(unsigned length)
+    {
+        std::string tempStr;
+        tempStr.assign(length, '\0');
+        m_Stream.read(&tempStr[0], length);
+        return tempStr;
+    }
+
+    std::string ReadPStr()
+    {
+        // P-Strings (Pascal strings) are prefixed with a 1 byte length
+        uint8_t stringLength = m_Stream.get();
+        return ReadStr(stringLength);
+    }
+
+    std::vector<char> ReadBytes(unsigned length)
+    {
+        std::vector<char> tempBytes;
+        tempBytes.assign(length, '\0');
+        m_Stream.read(&tempBytes[0], length);
+        return tempBytes;
+    }
+
+    template<typename T = uint8_t, size_t ReadAmount = sizeof(T), Endianness Endian = GlobalEndian, typename = std::enable_if_t<std::is_integral_v<T>>>
+    T ReadInt()
+    {
+        static_assert(ReadAmount <= sizeof(T), "Explicitly specified template parameter 'ReadAmount' must be <= sizeof(T)");
+        if constexpr (ReadAmount > 1UL)
+        {
+            static_assert(is_power_of_two<sizeof(T)>, "sizeof(T) must be a power of 2");
+            static_assert(Endian != Endianness::Unspecified, "Set the endianness when creating StreamReader or set it in this method's template parameters");
+            if constexpr (Endian == Endianness::Little)
+                return ReadIntLittleEndian<T, ReadAmount>();
+            else
+                return ReadIntBigEndian<T, ReadAmount>();
+        }
+        else
+        {
+            return m_Stream.get();
+        }
+    }
+
+};
+
+} // namespace d2m

--- a/include/utils/stream_reader.h
+++ b/include/utils/stream_reader.h
@@ -9,7 +9,6 @@
 #pragma once
 
 #include <istream>
-#include <memory>
 #include <type_traits>
 #include <string>
 #include <vector>
@@ -156,7 +155,7 @@ public:
         static_assert(ReadAmount <= sizeof(T), "Explicitly specified template parameter 'ReadAmount' must be <= sizeof(T)");
         if constexpr (ReadAmount > 1UL)
         {
-            static_assert(is_power_of_two<sizeof(T)>, "sizeof(T) must be a power of 2");
+            static_assert(is_power_of_two<sizeof(T)>, "sizeof(T) must be a power of 2"); // TODO: Unnecessary?
             static_assert(Endian != Endianness::Unspecified, "Set the endianness when creating StreamReader or set it in this method's template parameters");
             if constexpr (Endian == Endianness::Little)
                 return ReadIntLittleEndian<T, ReadAmount>();
@@ -168,7 +167,6 @@ public:
             return m_Stream.get();
         }
     }
-
 };
 
 } // namespace d2m


### PR DESCRIPTION
This PR implements an std::istream wrapper named `StreamReader`.

`StreamReader` can read integers of arbitrary size using either type of endianness. It can automatically deduce the number of bytes to read through the template parameter, or it can be explicitly specified. If the number of bytes to read is less than the number bytes in the return type, it will sign extend the result if it needs to. The loops it uses are unrolled at compile-time for optimal performance. It also provides methods for reading strings, including P-Strings (Pascal strings).

The DMF class has been refactored to use `StreamReader`.