### PR TITLE
Generated Data

### DIFF
--- a/include/core/conversion_options.h
+++ b/include/core/conversion_options.h
@@ -36,7 +36,7 @@ struct Info<ConversionOptionsBase> : public InfoBase
 
 
 // Base class for conversion options
-class ConversionOptionsBase : public OptionCollection, public EnableReflection<ConversionOptionsBase>
+class ConversionOptionsBase : public OptionCollection, public EnableReflection<ConversionOptionsBase>, public std::enable_shared_from_this<ConversionOptionsBase>
 {
 protected:
 
@@ -45,6 +45,15 @@ protected:
 public:
 
     virtual ~ConversionOptionsBase() = default;
+
+    /*
+     * Cast ConversionOptionsPtr to std::shared_ptr<T> where T is the derived ConversionOptions class
+     */
+    template<class T, std::enable_if_t<std::is_base_of_v<ConversionOptionsBase, T>, bool> = true>
+    std::shared_ptr<T> Cast() const
+    {
+        return std::static_pointer_cast<T>(shared_from_this());
+    }
 
     /*
      * Get the filename of the output file. Returns empty string if error occurred.

--- a/include/core/conversion_options.h
+++ b/include/core/conversion_options.h
@@ -9,7 +9,6 @@
 #pragma once
 
 #include "factory.h"
-#include "module.h"
 #include "utils.h"
 #include "options.h"
 

--- a/include/core/data.h
+++ b/include/core/data.h
@@ -15,6 +15,11 @@
 
 namespace d2m {
 
+using order_index_t = uint16_t;
+using pattern_index_t = uint16_t;
+using channel_index_t = uint8_t;
+using row_index_t = uint16_t;
+
 enum class DataStorageType
 {
     None,
@@ -27,16 +32,16 @@ enum class DataStorageType
     Can be customized if a module type has more global information to be stored.
 */
 
-template <DataStorageType DataStorage = DataStorageType::None>
-struct ModuleGlobalDataGeneric
+template<DataStorageType DataStorage = DataStorageType::None>
+struct ModuleGlobalDataDefault
 {
     static constexpr DataStorageType StorageType = DataStorage;
     std::string title;
     std::string author;
 };
 
-template <class ModuleClass>
-struct ModuleGlobalData : public ModuleGlobalDataGeneric<> {};
+template<class ModuleClass>
+struct ModuleGlobalData : public ModuleGlobalDataDefault<> {};
 
 /*
     Different modules have significantly different per-channel row contents, so
@@ -44,13 +49,13 @@ struct ModuleGlobalData : public ModuleGlobalDataGeneric<> {};
     make much sense. Each module should provide their own Row implementation.
 */
 
-struct RowGeneric
+struct RowDefault
 {
     NoteSlot note;
 };
 
-template <class ModuleClass>
-struct Row : public RowGeneric {};
+template<class ModuleClass>
+struct Row : public RowDefault {};
 
 /*
     Some module formats contain additional data for each channel or row.
@@ -58,21 +63,21 @@ struct Row : public RowGeneric {};
     for any module format which requires it.
 */
 
-struct ChannelMetadataGeneric
+struct ChannelMetadataDefault
+{
+    // No defaults at this time
+};
+
+template<class ModuleClass>
+struct ChannelMetadata : public ChannelMetadataDefault {};
+
+struct PatternMetadataDefault
 {
     // No defaults at this time
 };
 
 template <class ModuleClass>
-struct ChannelMetadata : public ChannelMetadataGeneric {};
-
-struct PatternMetadataGeneric
-{
-    // No defaults at this time
-};
-
-template <class ModuleClass>
-struct PatternMetadata : public PatternMetadataGeneric {};
+struct PatternMetadata : public PatternMetadataDefault {};
 
 
 namespace detail
@@ -94,20 +99,20 @@ namespace detail
     class ModuleDataStorageBase
     {
     public:
-        inline unsigned GetNumChannels() const { return m_NumChannels; }
-        inline unsigned GetNumOrders() const { return m_NumOrders; }
-        inline unsigned GetNumRows() const { return m_NumRows; }
+        inline channel_index_t GetNumChannels() const { return m_NumChannels; }
+        inline order_index_t GetNumOrders() const { return m_NumOrders; }
+        inline row_index_t GetNumRows() const { return m_NumRows; }
     protected:
         virtual void CleanUpData() = 0;
         virtual void SetPatternMatrix() = 0;
         virtual void SetNumPatterns() = 0;
         virtual void SetPatterns() = 0;
-        unsigned m_NumChannels;
-        unsigned m_NumOrders;    // Total orders (pattern matrix rows)
-        unsigned m_NumRows;      // Rows per pattern
+        channel_index_t m_NumChannels;
+        order_index_t m_NumOrders;    // Total orders (pattern matrix rows)
+        row_index_t m_NumRows;      // Rows per pattern
     };
 
-    template <DataStorageType StorageType, class ModuleClass>
+    template<DataStorageType StorageType, class ModuleClass>
     class ModuleDataStorage : public ModuleDataStorageBase
     {
     protected:
@@ -120,7 +125,7 @@ namespace detail
         void SetPatterns() override {}
     };
 
-    template <class ModuleClass>
+    template<class ModuleClass>
     class ModuleDataStorage<DataStorageType::COR, ModuleClass> : public ModuleDataStorageBase
     {
     protected:
@@ -130,10 +135,10 @@ namespace detail
         {
             if (!m_NumPatterns.empty())
             {
-                unsigned channel = 0;
+                channel_index_t channel = 0;
                 for (const auto& numPatterns : m_NumPatterns)
                 {
-                    for (unsigned patternId = 0; patternId < numPatterns; ++patternId)
+                    for (pattern_index_t patternId = 0; patternId < numPatterns; ++patternId)
                     {
                         delete[] m_Patterns[channel][patternId];
                         m_Patterns[channel][patternId] = nullptr;
@@ -153,7 +158,7 @@ namespace detail
         {
             m_PatternMatrix.resize(m_NumChannels);
 
-            for (unsigned channel = 0; channel < m_NumChannels; ++channel)
+            for (channel_index_t channel = 0; channel < m_NumChannels; ++channel)
             {
                 m_PatternMatrix[channel].resize(m_NumOrders);
             }
@@ -162,7 +167,7 @@ namespace detail
         {
             m_NumPatterns.resize(m_NumChannels);
 
-            for (unsigned channel = 0; channel < m_NumChannels; ++channel)
+            for (channel_index_t channel = 0; channel < m_NumChannels; ++channel)
             {
                 m_NumPatterns[channel] = *std::max_element(m_PatternMatrix[channel].begin(), m_PatternMatrix[channel].end()) + 1;
             }
@@ -176,12 +181,12 @@ namespace detail
                 m_PatternMetadata.resize(m_NumChannels);
             }
 
-            for (unsigned channel = 0; channel < m_NumChannels; ++channel)
+            for (channel_index_t channel = 0; channel < m_NumChannels; ++channel)
             {
-                const uint8_t numPatterns = m_NumPatterns[channel];
+                const pattern_index_t numPatterns = m_NumPatterns[channel];
                 m_Patterns[channel] = new PatternType[numPatterns];
 
-                for (unsigned patternId = 0; patternId < numPatterns; ++patternId)
+                for (pattern_index_t patternId = 0; patternId < numPatterns; ++patternId)
                 {
                     m_Patterns[channel][patternId] = new RowType[m_NumRows]();
                     if constexpr (!std::is_empty_v<PatternMetadataType>)
@@ -197,26 +202,26 @@ namespace detail
         using RowType = Row<ModuleClass>;
         using PatternType = RowType*; // [row]
 
-        using PatternMatrixType = std::vector<std::vector<uint8_t>>; // [channel][order]
-        using NumPatternsType = std::vector<uint8_t>; // [channel]
+        using PatternMatrixType = std::vector<std::vector<pattern_index_t>>; // [channel][order]
+        using NumPatternsType = std::vector<pattern_index_t>; // [channel]
         using PatternStorageType = std::vector<PatternType*>; // [channel][pattern id]
         using PatternMetadataType = PatternMetadata<ModuleClass>;
         using PatternMetadataStorageType = std::vector<std::vector<PatternMetadataType>>; // [channel][pattern id]
 
-        inline uint8_t GetPatternId(unsigned channel, unsigned order) const { return m_PatternMatrix[channel][order]; }
-        inline void SetPatternId(unsigned channel, unsigned order, uint8_t patternId) { m_PatternMatrix[channel][order] = patternId; }
-        inline uint8_t GetNumPatterns(unsigned channel) const { return m_NumPatterns[channel]; }
-        inline void SetNumPatterns(unsigned channel, uint8_t numPatterns) { m_NumPatterns[channel] = numPatterns; }
-        inline PatternType GetPattern(unsigned channel, unsigned order) const { return m_Patterns[channel][GetPatternId(channel, order)]; }
-        inline void SetPattern(unsigned channel, unsigned order, PatternType&& pattern) { m_Patterns[channel][GetPatternId(channel, order)] = std::move(pattern); } // TODO: Deep copy?
-        inline PatternType GetPatternById(unsigned channel, unsigned patternId) const { return m_Patterns[channel][patternId]; }
-        inline void SetPatternById(unsigned channel, unsigned patternId, PatternType&& pattern) { m_Patterns[channel][patternId] = std::move(pattern); } // TODO: Deep copy?
-        inline const RowType& GetRow(unsigned channel, unsigned order, unsigned row) const { return GetPattern(channel, order)[row]; }
-        inline void SetRow(unsigned channel, unsigned order, unsigned row, const RowType& rowValue) { GetPattern(channel, order)[row] = rowValue; }
-        inline const RowType& GetRowById(unsigned channel, unsigned patternId, unsigned row) const { return GetPatternById(channel, patternId)[row]; }
-        inline void SetRowById(unsigned channel, unsigned patternId, unsigned row, const RowType& rowValue) { GetPatternById(channel, patternId)[row] = rowValue; }
-        inline const PatternMetadataType& GetPatternMetadata(unsigned channel, unsigned patternId) const { return m_PatternMetadata[channel][patternId]; }
-        inline void SetPatternMetadata(unsigned channel, unsigned patternId, const PatternMetadataType& patternMetadata) { m_PatternMetadata[channel][patternId] = patternMetadata; }
+        inline uint8_t GetPatternId(channel_index_t channel, order_index_t order) const { return m_PatternMatrix[channel][order]; }
+        inline void SetPatternId(channel_index_t channel, order_index_t order, pattern_index_t patternId) { m_PatternMatrix[channel][order] = patternId; }
+        inline uint8_t GetNumPatterns(channel_index_t channel) const { return m_NumPatterns[channel]; }
+        inline void SetNumPatterns(channel_index_t channel, pattern_index_t numPatterns) { m_NumPatterns[channel] = numPatterns; }
+        inline PatternType GetPattern(channel_index_t channel, order_index_t order) const { return m_Patterns[channel][GetPatternId(channel, order)]; }
+        inline void SetPattern(channel_index_t channel, order_index_t order, PatternType&& pattern) { m_Patterns[channel][GetPatternId(channel, order)] = std::move(pattern); } // TODO: Deep copy?
+        inline PatternType GetPatternById(channel_index_t channel, pattern_index_t patternId) const { return m_Patterns[channel][patternId]; }
+        inline void SetPatternById(channel_index_t channel, pattern_index_t patternId, PatternType&& pattern) { m_Patterns[channel][patternId] = std::move(pattern); } // TODO: Deep copy?
+        inline const RowType& GetRow(channel_index_t channel, order_index_t order, row_index_t row) const { return GetPattern(channel, order)[row]; }
+        inline void SetRow(channel_index_t channel, order_index_t order, row_index_t row, const RowType& rowValue) { GetPattern(channel, order)[row] = rowValue; }
+        inline const RowType& GetRowById(channel_index_t channel, pattern_index_t patternId, row_index_t row) const { return GetPatternById(channel, patternId)[row]; }
+        inline void SetRowById(channel_index_t channel, pattern_index_t patternId, row_index_t row, const RowType& rowValue) { GetPatternById(channel, patternId)[row] = rowValue; }
+        inline const PatternMetadataType& GetPatternMetadata(channel_index_t channel, pattern_index_t patternId) const { return m_PatternMetadata[channel][patternId]; }
+        inline void SetPatternMetadata(channel_index_t channel, pattern_index_t patternId, const PatternMetadataType& patternMetadata) { m_PatternMetadata[channel][patternId] = patternMetadata; }
 
     protected:
         PatternMatrixType m_PatternMatrix{};  // Stores patterns IDs for each channel and order in the pattern matrix
@@ -225,7 +230,7 @@ namespace detail
         PatternMetadataStorageType m_PatternMetadata{}; // [channel][pattern id]
     };
 
-    template <class ModuleClass>
+    template<class ModuleClass>
     class ModuleDataStorage<DataStorageType::ORC, ModuleClass> : public ModuleDataStorageBase
     {
     protected:
@@ -233,9 +238,9 @@ namespace detail
         ~ModuleDataStorage() { CleanUpData(); }
         void CleanUpData() override
         {
-            for (unsigned patternId = 0; patternId < m_NumPatterns; ++patternId)
+            for (pattern_index_t patternId = 0; patternId < m_NumPatterns; ++patternId)
             {
-                for (unsigned row = 0; row < m_NumRows; ++row)
+                for (row_index_t row = 0; row < m_NumRows; ++row)
                 {
                     delete[] m_Patterns[patternId][row];
                     m_Patterns[patternId][row] = nullptr;
@@ -267,10 +272,10 @@ namespace detail
                 m_PatternMetadata.resize(m_NumPatterns);
             }
 
-            for (unsigned patternId = 0; patternId < m_NumPatterns; ++patternId)
+            for (pattern_index_t patternId = 0; patternId < m_NumPatterns; ++patternId)
             {
                 m_Patterns[patternId] = new RowType*[m_NumRows];
-                for (unsigned row = 0; row < m_NumRows; ++row)
+                for (row_index_t row = 0; row < m_NumRows; ++row)
                 {
                     m_Patterns[patternId][row] = new RowType[m_NumChannels]();
                 }
@@ -281,26 +286,26 @@ namespace detail
         using RowType = Row<ModuleClass>;
         using PatternType = RowType**; // [row][channel]
 
-        using PatternMatrixType = std::vector<uint8_t>; // [order] (No per-channel patterns)
-        using NumPatternsType = uint8_t; // (No per-channel patterns)
+        using PatternMatrixType = std::vector<pattern_index_t>; // [order] (No per-channel patterns)
+        using NumPatternsType = pattern_index_t; // (No per-channel patterns)
         using PatternStorageType = std::vector<PatternType>; // [order]
         using PatternMetadataType = PatternMetadata<ModuleClass>;
         using PatternMetadataStorageType = std::vector<PatternMetadataType>; // [pattern id] (No per-channel patterns)
 
-        inline uint8_t GetPatternId(unsigned order) const { return m_PatternMatrix[order]; }
-        inline void SetPatternId(unsigned order, uint8_t patternId) { m_PatternMatrix[order] = patternId; }
-        inline uint8_t GetNumPatterns() const { return m_NumPatterns; }
-        inline void SetNumPatterns(uint8_t numPatterns) { m_NumPatterns = numPatterns; }
-        inline PatternType GetPattern(unsigned order) const { return m_Patterns[GetPatternId(order)]; }
-        inline void SetPattern(unsigned order, PatternType&& pattern) { m_Patterns[GetPatternId(order)] = std::move(pattern); } // TODO: Deep copy?
-        inline PatternType GetPatternById(unsigned patternId) const { return m_Patterns[patternId]; }
-        inline void SetPatternById(unsigned patternId, PatternType&& pattern) { m_Patterns[patternId] = std::move(pattern); } // TODO: Deep copy?
-        inline const RowType& GetRow(unsigned channel, unsigned order, unsigned row) const { return GetPattern(order)[row][channel]; }
-        inline void SetRow(unsigned channel, unsigned order, unsigned row, const RowType& rowValue) { GetPattern(order)[row][channel] = rowValue; }
-        inline const RowType& GetRowById(unsigned channel, unsigned patternId, unsigned row) const { return GetPatternById(patternId)[row][channel]; }
-        inline void SetRowById(unsigned channel, unsigned patternId, unsigned row, const RowType& rowValue) { GetPatternById(patternId)[row][channel] = rowValue; }
-        inline const PatternMetadataType& GetPatternMetadata(unsigned patternId) const { return m_PatternMetadata[patternId]; }
-        inline void SetPatternMetadata(unsigned patternId, const PatternMetadataType& patternMetadata) { m_PatternMetadata[patternId] = patternMetadata; }
+        inline pattern_index_t GetPatternId(order_index_t order) const { return m_PatternMatrix[order]; }
+        inline void SetPatternId(order_index_t order, pattern_index_t patternId) { m_PatternMatrix[order] = patternId; }
+        inline pattern_index_t GetNumPatterns() const { return m_NumPatterns; }
+        inline void SetNumPatterns(pattern_index_t numPatterns) { m_NumPatterns = numPatterns; }
+        inline PatternType GetPattern(order_index_t order) const { return m_Patterns[GetPatternId(order)]; }
+        inline void SetPattern(order_index_t order, PatternType&& pattern) { m_Patterns[GetPatternId(order)] = std::move(pattern); } // TODO: Deep copy?
+        inline PatternType GetPatternById(pattern_index_t patternId) const { return m_Patterns[patternId]; }
+        inline void SetPatternById(pattern_index_t patternId, PatternType&& pattern) { m_Patterns[patternId] = std::move(pattern); } // TODO: Deep copy?
+        inline const RowType& GetRow(channel_index_t channel, order_index_t order, row_index_t row) const { return GetPattern(order)[row][channel]; }
+        inline void SetRow(channel_index_t channel, order_index_t order, row_index_t row, const RowType& rowValue) { GetPattern(order)[row][channel] = rowValue; }
+        inline const RowType& GetRowById(channel_index_t channel, pattern_index_t patternId, row_index_t row) const { return GetPatternById(patternId)[row][channel]; }
+        inline void SetRowById(channel_index_t channel, pattern_index_t patternId, row_index_t row, const RowType& rowValue) { GetPatternById(patternId)[row][channel] = rowValue; }
+        inline const PatternMetadataType& GetPatternMetadata(pattern_index_t patternId) const { return m_PatternMetadata[patternId]; }
+        inline void SetPatternMetadata(pattern_index_t patternId, const PatternMetadataType& patternMetadata) { m_PatternMetadata[patternId] = patternMetadata; }
 
     protected:
         PatternMatrixType m_PatternMatrix{};  // Stores patterns IDs for each order in the pattern matrix
@@ -319,7 +324,7 @@ namespace detail
     orders, patterns, rows, and other information.
 */
 
-template <class ModuleClass>
+template<class ModuleClass>
 class ModuleData : public detail::ModuleDataStorage<ModuleGlobalData<ModuleClass>::StorageType, ModuleClass>
 {
 public:
@@ -337,7 +342,7 @@ public:
     ~ModuleData() { CleanUp(); }
 
     // This is the 1st initialization method to call
-    void AllocatePatternMatrix(unsigned channels, unsigned orders, unsigned rows)
+    void AllocatePatternMatrix(channel_index_t channels, order_index_t orders, row_index_t rows)
     {
         Storage::CleanUpData();
 
@@ -389,8 +394,8 @@ public:
 
     /////// GETTERS / SETTERS ///////
 
-    inline const ChannelMetadataType& GetChannelMetadata(unsigned channel) const { return m_ChannelMetadata[channel]; }
-    inline void SetChannelMetadata(unsigned channel, const ChannelMetadataType& channelMetadata) { m_ChannelMetadata[channel] = channelMetadata; }
+    inline const ChannelMetadataType& GetChannelMetadata(channel_index_t channel) const { return m_ChannelMetadata[channel]; }
+    inline void SetChannelMetadata(channel_index_t channel, const ChannelMetadataType& channelMetadata) { m_ChannelMetadata[channel] = channelMetadata; }
 
     static inline constexpr DataStorageType GetStorageType() { return StorageType; }
 

--- a/include/core/data.h
+++ b/include/core/data.h
@@ -2,7 +2,7 @@
     data.h
     Written by Dalton Messmer <messmer.dalton@gmail.com>.
 
-    Defines a class for storing and accessing module data (orders, patterns, rows, etc.)
+    Defines a class template for storing and accessing module data (orders, patterns, rows, etc.)
 */
 
 #pragma once

--- a/include/core/data.h
+++ b/include/core/data.h
@@ -208,9 +208,9 @@ namespace detail
         using PatternMetadataType = PatternMetadata<ModuleClass>;
         using PatternMetadataStorageType = std::vector<std::vector<PatternMetadataType>>; // [channel][pattern id]
 
-        inline uint8_t GetPatternId(channel_index_t channel, order_index_t order) const { return m_PatternMatrix[channel][order]; }
+        inline pattern_index_t GetPatternId(channel_index_t channel, order_index_t order) const { return m_PatternMatrix[channel][order]; }
         inline void SetPatternId(channel_index_t channel, order_index_t order, pattern_index_t patternId) { m_PatternMatrix[channel][order] = patternId; }
-        inline uint8_t GetNumPatterns(channel_index_t channel) const { return m_NumPatterns[channel]; }
+        inline pattern_index_t GetNumPatterns(channel_index_t channel) const { return m_NumPatterns[channel]; }
         inline void SetNumPatterns(channel_index_t channel, pattern_index_t numPatterns) { m_NumPatterns[channel] = numPatterns; }
         inline PatternType GetPattern(channel_index_t channel, order_index_t order) const { return m_Patterns[channel][GetPatternId(channel, order)]; }
         inline void SetPattern(channel_index_t channel, order_index_t order, PatternType&& pattern) { m_Patterns[channel][GetPatternId(channel, order)] = std::move(pattern); } // TODO: Deep copy?
@@ -224,7 +224,7 @@ namespace detail
         inline void SetPatternMetadata(channel_index_t channel, pattern_index_t patternId, const PatternMetadataType& patternMetadata) { m_PatternMetadata[channel][patternId] = patternMetadata; }
 
     protected:
-        PatternMatrixType m_PatternMatrix{};  // Stores patterns IDs for each channel and order in the pattern matrix
+        PatternMatrixType m_PatternMatrix{}; // Stores patterns IDs for each channel and order in the pattern matrix
         NumPatternsType m_NumPatterns{}; // Patterns per channel
         PatternStorageType m_Patterns{}; // [channel][pattern id]
         PatternMetadataStorageType m_PatternMetadata{}; // [channel][pattern id]
@@ -308,7 +308,7 @@ namespace detail
         inline void SetPatternMetadata(pattern_index_t patternId, const PatternMetadataType& patternMetadata) { m_PatternMetadata[patternId] = patternMetadata; }
 
     protected:
-        PatternMatrixType m_PatternMatrix{};  // Stores patterns IDs for each order in the pattern matrix
+        PatternMatrixType m_PatternMatrix{}; // Stores patterns IDs for each order in the pattern matrix
         NumPatternsType m_NumPatterns{}; // Number of patterns
         PatternStorageType m_Patterns{}; // [pattern id]
         PatternMetadataStorageType m_PatternMetadata{}; // [pattern id]

--- a/include/core/data.h
+++ b/include/core/data.h
@@ -15,10 +15,10 @@
 
 namespace d2m {
 
-using order_index_t = uint16_t;
-using pattern_index_t = uint16_t;
-using channel_index_t = uint8_t;
-using row_index_t = uint16_t;
+using OrderIndex = uint16_t;
+using PatternIndex = uint16_t;
+using ChannelIndex = uint8_t;
+using RowIndex = uint16_t;
 
 enum class DataStorageType
 {
@@ -99,17 +99,17 @@ namespace detail
     class ModuleDataStorageBase
     {
     public:
-        inline channel_index_t GetNumChannels() const { return m_NumChannels; }
-        inline order_index_t GetNumOrders() const { return m_NumOrders; }
-        inline row_index_t GetNumRows() const { return m_NumRows; }
+        inline ChannelIndex GetNumChannels() const { return m_NumChannels; }
+        inline OrderIndex GetNumOrders() const { return m_NumOrders; }
+        inline RowIndex GetNumRows() const { return m_NumRows; }
     protected:
         virtual void CleanUpData() = 0;
         virtual void SetPatternMatrix() = 0;
         virtual void SetNumPatterns() = 0;
         virtual void SetPatterns() = 0;
-        channel_index_t m_NumChannels;
-        order_index_t m_NumOrders;    // Total orders (pattern matrix rows)
-        row_index_t m_NumRows;      // Rows per pattern
+        ChannelIndex m_NumChannels;
+        OrderIndex m_NumOrders;    // Total orders (pattern matrix rows)
+        RowIndex m_NumRows;      // Rows per pattern
     };
 
     template<DataStorageType StorageType, class ModuleClass>
@@ -135,10 +135,10 @@ namespace detail
         {
             if (!m_NumPatterns.empty())
             {
-                channel_index_t channel = 0;
+                ChannelIndex channel = 0;
                 for (const auto& numPatterns : m_NumPatterns)
                 {
-                    for (pattern_index_t patternId = 0; patternId < numPatterns; ++patternId)
+                    for (PatternIndex patternId = 0; patternId < numPatterns; ++patternId)
                     {
                         delete[] m_Patterns[channel][patternId];
                         m_Patterns[channel][patternId] = nullptr;
@@ -158,7 +158,7 @@ namespace detail
         {
             m_PatternMatrix.resize(m_NumChannels);
 
-            for (channel_index_t channel = 0; channel < m_NumChannels; ++channel)
+            for (ChannelIndex channel = 0; channel < m_NumChannels; ++channel)
             {
                 m_PatternMatrix[channel].resize(m_NumOrders);
             }
@@ -167,7 +167,7 @@ namespace detail
         {
             m_NumPatterns.resize(m_NumChannels);
 
-            for (channel_index_t channel = 0; channel < m_NumChannels; ++channel)
+            for (ChannelIndex channel = 0; channel < m_NumChannels; ++channel)
             {
                 m_NumPatterns[channel] = *std::max_element(m_PatternMatrix[channel].begin(), m_PatternMatrix[channel].end()) + 1;
             }
@@ -181,12 +181,12 @@ namespace detail
                 m_PatternMetadata.resize(m_NumChannels);
             }
 
-            for (channel_index_t channel = 0; channel < m_NumChannels; ++channel)
+            for (ChannelIndex channel = 0; channel < m_NumChannels; ++channel)
             {
-                const pattern_index_t numPatterns = m_NumPatterns[channel];
+                const PatternIndex numPatterns = m_NumPatterns[channel];
                 m_Patterns[channel] = new PatternType[numPatterns];
 
-                for (pattern_index_t patternId = 0; patternId < numPatterns; ++patternId)
+                for (PatternIndex patternId = 0; patternId < numPatterns; ++patternId)
                 {
                     m_Patterns[channel][patternId] = new RowType[m_NumRows]();
                     if constexpr (!std::is_empty_v<PatternMetadataType>)
@@ -202,26 +202,26 @@ namespace detail
         using RowType = Row<ModuleClass>;
         using PatternType = RowType*; // [row]
 
-        using PatternMatrixType = std::vector<std::vector<pattern_index_t>>; // [channel][order]
-        using NumPatternsType = std::vector<pattern_index_t>; // [channel]
+        using PatternMatrixType = std::vector<std::vector<PatternIndex>>; // [channel][order]
+        using NumPatternsType = std::vector<PatternIndex>; // [channel]
         using PatternStorageType = std::vector<PatternType*>; // [channel][pattern id]
         using PatternMetadataType = PatternMetadata<ModuleClass>;
         using PatternMetadataStorageType = std::vector<std::vector<PatternMetadataType>>; // [channel][pattern id]
 
-        inline pattern_index_t GetPatternId(channel_index_t channel, order_index_t order) const { return m_PatternMatrix[channel][order]; }
-        inline void SetPatternId(channel_index_t channel, order_index_t order, pattern_index_t patternId) { m_PatternMatrix[channel][order] = patternId; }
-        inline pattern_index_t GetNumPatterns(channel_index_t channel) const { return m_NumPatterns[channel]; }
-        inline void SetNumPatterns(channel_index_t channel, pattern_index_t numPatterns) { m_NumPatterns[channel] = numPatterns; }
-        inline PatternType GetPattern(channel_index_t channel, order_index_t order) const { return m_Patterns[channel][GetPatternId(channel, order)]; }
-        inline void SetPattern(channel_index_t channel, order_index_t order, PatternType&& pattern) { m_Patterns[channel][GetPatternId(channel, order)] = std::move(pattern); } // TODO: Deep copy?
-        inline PatternType GetPatternById(channel_index_t channel, pattern_index_t patternId) const { return m_Patterns[channel][patternId]; }
-        inline void SetPatternById(channel_index_t channel, pattern_index_t patternId, PatternType&& pattern) { m_Patterns[channel][patternId] = std::move(pattern); } // TODO: Deep copy?
-        inline const RowType& GetRow(channel_index_t channel, order_index_t order, row_index_t row) const { return GetPattern(channel, order)[row]; }
-        inline void SetRow(channel_index_t channel, order_index_t order, row_index_t row, const RowType& rowValue) { GetPattern(channel, order)[row] = rowValue; }
-        inline const RowType& GetRowById(channel_index_t channel, pattern_index_t patternId, row_index_t row) const { return GetPatternById(channel, patternId)[row]; }
-        inline void SetRowById(channel_index_t channel, pattern_index_t patternId, row_index_t row, const RowType& rowValue) { GetPatternById(channel, patternId)[row] = rowValue; }
-        inline const PatternMetadataType& GetPatternMetadata(channel_index_t channel, pattern_index_t patternId) const { return m_PatternMetadata[channel][patternId]; }
-        inline void SetPatternMetadata(channel_index_t channel, pattern_index_t patternId, const PatternMetadataType& patternMetadata) { m_PatternMetadata[channel][patternId] = patternMetadata; }
+        inline PatternIndex GetPatternId(ChannelIndex channel, OrderIndex order) const { return m_PatternMatrix[channel][order]; }
+        inline void SetPatternId(ChannelIndex channel, OrderIndex order, PatternIndex patternId) { m_PatternMatrix[channel][order] = patternId; }
+        inline PatternIndex GetNumPatterns(ChannelIndex channel) const { return m_NumPatterns[channel]; }
+        inline void SetNumPatterns(ChannelIndex channel, PatternIndex numPatterns) { m_NumPatterns[channel] = numPatterns; }
+        inline PatternType GetPattern(ChannelIndex channel, OrderIndex order) const { return m_Patterns[channel][GetPatternId(channel, order)]; }
+        inline void SetPattern(ChannelIndex channel, OrderIndex order, PatternType&& pattern) { m_Patterns[channel][GetPatternId(channel, order)] = std::move(pattern); } // TODO: Deep copy?
+        inline PatternType GetPatternById(ChannelIndex channel, PatternIndex patternId) const { return m_Patterns[channel][patternId]; }
+        inline void SetPatternById(ChannelIndex channel, PatternIndex patternId, PatternType&& pattern) { m_Patterns[channel][patternId] = std::move(pattern); } // TODO: Deep copy?
+        inline const RowType& GetRow(ChannelIndex channel, OrderIndex order, RowIndex row) const { return GetPattern(channel, order)[row]; }
+        inline void SetRow(ChannelIndex channel, OrderIndex order, RowIndex row, const RowType& rowValue) { GetPattern(channel, order)[row] = rowValue; }
+        inline const RowType& GetRowById(ChannelIndex channel, PatternIndex patternId, RowIndex row) const { return GetPatternById(channel, patternId)[row]; }
+        inline void SetRowById(ChannelIndex channel, PatternIndex patternId, RowIndex row, const RowType& rowValue) { GetPatternById(channel, patternId)[row] = rowValue; }
+        inline const PatternMetadataType& GetPatternMetadata(ChannelIndex channel, PatternIndex patternId) const { return m_PatternMetadata[channel][patternId]; }
+        inline void SetPatternMetadata(ChannelIndex channel, PatternIndex patternId, const PatternMetadataType& patternMetadata) { m_PatternMetadata[channel][patternId] = patternMetadata; }
 
     protected:
         PatternMatrixType m_PatternMatrix{}; // Stores patterns IDs for each channel and order in the pattern matrix
@@ -238,9 +238,9 @@ namespace detail
         ~ModuleDataStorage() { CleanUpData(); }
         void CleanUpData() override
         {
-            for (pattern_index_t patternId = 0; patternId < m_NumPatterns; ++patternId)
+            for (PatternIndex patternId = 0; patternId < m_NumPatterns; ++patternId)
             {
-                for (row_index_t row = 0; row < m_NumRows; ++row)
+                for (RowIndex row = 0; row < m_NumRows; ++row)
                 {
                     delete[] m_Patterns[patternId][row];
                     m_Patterns[patternId][row] = nullptr;
@@ -272,10 +272,10 @@ namespace detail
                 m_PatternMetadata.resize(m_NumPatterns);
             }
 
-            for (pattern_index_t patternId = 0; patternId < m_NumPatterns; ++patternId)
+            for (PatternIndex patternId = 0; patternId < m_NumPatterns; ++patternId)
             {
                 m_Patterns[patternId] = new RowType*[m_NumRows];
-                for (row_index_t row = 0; row < m_NumRows; ++row)
+                for (RowIndex row = 0; row < m_NumRows; ++row)
                 {
                     m_Patterns[patternId][row] = new RowType[m_NumChannels]();
                 }
@@ -286,26 +286,26 @@ namespace detail
         using RowType = Row<ModuleClass>;
         using PatternType = RowType**; // [row][channel]
 
-        using PatternMatrixType = std::vector<pattern_index_t>; // [order] (No per-channel patterns)
-        using NumPatternsType = pattern_index_t; // (No per-channel patterns)
+        using PatternMatrixType = std::vector<PatternIndex>; // [order] (No per-channel patterns)
+        using NumPatternsType = PatternIndex; // (No per-channel patterns)
         using PatternStorageType = std::vector<PatternType>; // [order]
         using PatternMetadataType = PatternMetadata<ModuleClass>;
         using PatternMetadataStorageType = std::vector<PatternMetadataType>; // [pattern id] (No per-channel patterns)
 
-        inline pattern_index_t GetPatternId(order_index_t order) const { return m_PatternMatrix[order]; }
-        inline void SetPatternId(order_index_t order, pattern_index_t patternId) { m_PatternMatrix[order] = patternId; }
-        inline pattern_index_t GetNumPatterns() const { return m_NumPatterns; }
-        inline void SetNumPatterns(pattern_index_t numPatterns) { m_NumPatterns = numPatterns; }
-        inline PatternType GetPattern(order_index_t order) const { return m_Patterns[GetPatternId(order)]; }
-        inline void SetPattern(order_index_t order, PatternType&& pattern) { m_Patterns[GetPatternId(order)] = std::move(pattern); } // TODO: Deep copy?
-        inline PatternType GetPatternById(pattern_index_t patternId) const { return m_Patterns[patternId]; }
-        inline void SetPatternById(pattern_index_t patternId, PatternType&& pattern) { m_Patterns[patternId] = std::move(pattern); } // TODO: Deep copy?
-        inline const RowType& GetRow(channel_index_t channel, order_index_t order, row_index_t row) const { return GetPattern(order)[row][channel]; }
-        inline void SetRow(channel_index_t channel, order_index_t order, row_index_t row, const RowType& rowValue) { GetPattern(order)[row][channel] = rowValue; }
-        inline const RowType& GetRowById(channel_index_t channel, pattern_index_t patternId, row_index_t row) const { return GetPatternById(patternId)[row][channel]; }
-        inline void SetRowById(channel_index_t channel, pattern_index_t patternId, row_index_t row, const RowType& rowValue) { GetPatternById(patternId)[row][channel] = rowValue; }
-        inline const PatternMetadataType& GetPatternMetadata(pattern_index_t patternId) const { return m_PatternMetadata[patternId]; }
-        inline void SetPatternMetadata(pattern_index_t patternId, const PatternMetadataType& patternMetadata) { m_PatternMetadata[patternId] = patternMetadata; }
+        inline PatternIndex GetPatternId(OrderIndex order) const { return m_PatternMatrix[order]; }
+        inline void SetPatternId(OrderIndex order, PatternIndex patternId) { m_PatternMatrix[order] = patternId; }
+        inline PatternIndex GetNumPatterns() const { return m_NumPatterns; }
+        inline void SetNumPatterns(PatternIndex numPatterns) { m_NumPatterns = numPatterns; }
+        inline PatternType GetPattern(OrderIndex order) const { return m_Patterns[GetPatternId(order)]; }
+        inline void SetPattern(OrderIndex order, PatternType&& pattern) { m_Patterns[GetPatternId(order)] = std::move(pattern); } // TODO: Deep copy?
+        inline PatternType GetPatternById(PatternIndex patternId) const { return m_Patterns[patternId]; }
+        inline void SetPatternById(PatternIndex patternId, PatternType&& pattern) { m_Patterns[patternId] = std::move(pattern); } // TODO: Deep copy?
+        inline const RowType& GetRow(ChannelIndex channel, OrderIndex order, RowIndex row) const { return GetPattern(order)[row][channel]; }
+        inline void SetRow(ChannelIndex channel, OrderIndex order, RowIndex row, const RowType& rowValue) { GetPattern(order)[row][channel] = rowValue; }
+        inline const RowType& GetRowById(ChannelIndex channel, PatternIndex patternId, RowIndex row) const { return GetPatternById(patternId)[row][channel]; }
+        inline void SetRowById(ChannelIndex channel, PatternIndex patternId, RowIndex row, const RowType& rowValue) { GetPatternById(patternId)[row][channel] = rowValue; }
+        inline const PatternMetadataType& GetPatternMetadata(PatternIndex patternId) const { return m_PatternMetadata[patternId]; }
+        inline void SetPatternMetadata(PatternIndex patternId, const PatternMetadataType& patternMetadata) { m_PatternMetadata[patternId] = patternMetadata; }
 
     protected:
         PatternMatrixType m_PatternMatrix{}; // Stores patterns IDs for each order in the pattern matrix
@@ -342,7 +342,7 @@ public:
     ~ModuleData() { CleanUp(); }
 
     // This is the 1st initialization method to call
-    void AllocatePatternMatrix(channel_index_t channels, order_index_t orders, row_index_t rows)
+    void AllocatePatternMatrix(ChannelIndex channels, OrderIndex orders, RowIndex rows)
     {
         Storage::CleanUpData();
 
@@ -394,8 +394,8 @@ public:
 
     /////// GETTERS / SETTERS ///////
 
-    inline const ChannelMetadataType& GetChannelMetadata(channel_index_t channel) const { return m_ChannelMetadata[channel]; }
-    inline void SetChannelMetadata(channel_index_t channel, const ChannelMetadataType& channelMetadata) { m_ChannelMetadata[channel] = channelMetadata; }
+    inline const ChannelMetadataType& GetChannelMetadata(ChannelIndex channel) const { return m_ChannelMetadata[channel]; }
+    inline void SetChannelMetadata(ChannelIndex channel, const ChannelMetadataType& channelMetadata) { m_ChannelMetadata[channel] = channelMetadata; }
 
     static inline constexpr DataStorageType GetStorageType() { return StorageType; }
 

--- a/include/core/effects.h
+++ b/include/core/effects.h
@@ -11,29 +11,44 @@
 
 namespace d2m {
 
-// All common effects are less than 0
-enum class CommonEffects : int8_t
+using EffectCode = int8_t;
+using EffectValue = int16_t;
+
+struct Effect
 {
-    NoEffect            =0,
-    Arp                 =-1,
-    PortUp              =-2,
-    PortDown            =-3,
-    Port2Note           =-4,
-    Vibrato             =-5,
-    Port2NoteVolSlide   =-6,
-    VibratoVolSlide     =-7,
-    Tremolo             =-8,
-    Panning             =-9,
-    VolSlide            =-10,
-    PosJump             =-11,
-    Retrigger           =-12,
-    PatBreak            =-13,
-    NoteCut             =-14,
-    NoteDelay           =-15,
-    Speed               =-16,
-    Tempo               =-17,
+    EffectCode code;
+    EffectValue value;
 };
 
-// Modules should implement effects specific to them using positive values starting with 1.
+inline constexpr bool operator==(const Effect& lhs, const Effect& rhs) { return lhs.code == rhs.code && lhs.value == rhs.value; }
+
+// Defines common effects used by multiple module types
+namespace Effects
+{
+    enum
+    {
+        // All common effects are less than 0
+        kNoEffect            =0,
+        kArp                 =-1,
+        kPortUp              =-2,
+        kPortDown            =-3,
+        kPort2Note           =-4,
+        kVibrato             =-5,
+        kPort2NoteVolSlide   =-6,
+        kVibratoVolSlide     =-7,
+        kTremolo             =-8,
+        kPanning             =-9,
+        kSpeedA              =-10,
+        kVolSlide            =-11,
+        kPosJump             =-12,
+        kRetrigger           =-13,
+        kPatBreak            =-14,
+        kNoteCut             =-15,
+        kNoteDelay           =-16,
+        kTempo               =-17,
+        kSpeedB              =-18,
+    };
+    // Modules should implement effects specific to them using positive values starting with 1.
+}
 
 } // namespace d2m

--- a/include/core/effects.h
+++ b/include/core/effects.h
@@ -22,6 +22,9 @@ struct Effect
 
 inline constexpr bool operator==(const Effect& lhs, const Effect& rhs) { return lhs.code == rhs.code && lhs.value == rhs.value; }
 
+// In Module data storage, this may be used, but in generated data, only the effects which actually have an effect should be present
+inline constexpr EffectValue kEffectValueless = -1;
+
 // Defines common effects used by multiple module types
 namespace Effects
 {

--- a/include/core/effects.h
+++ b/include/core/effects.h
@@ -1,0 +1,39 @@
+/*
+    effects.h
+    Written by Dalton Messmer <messmer.dalton@gmail.com>.
+
+    Defines effects which are common to many module file types
+*/
+
+#pragma once
+
+#include <cstdint>
+
+namespace d2m {
+
+// All common effects are less than 0
+enum class CommonEffects : int8_t
+{
+    NoEffect            =0,
+    Arp                 =-1,
+    PortUp              =-2,
+    PortDown            =-3,
+    Port2Note           =-4,
+    Vibrato             =-5,
+    Port2NoteVolSlide   =-6,
+    VibratoVolSlide     =-7,
+    Tremolo             =-8,
+    Panning             =-9,
+    VolSlide            =-10,
+    PosJump             =-11,
+    Retrigger           =-12,
+    PatBreak            =-13,
+    NoteCut             =-14,
+    NoteDelay           =-15,
+    Speed               =-16,
+    Tempo               =-17,
+};
+
+// Modules should implement effects specific to them using positive values starting with 1.
+
+} // namespace d2m

--- a/include/core/factory.h
+++ b/include/core/factory.h
@@ -249,7 +249,7 @@ struct ReflectionImpl : public Base
 
 // Inherit this class using CRTP to enable factory for any class
 template <class Derived, class Base>
-class EnableFactory : public detail::EnableFactoryBase, public std::conditional_t<detail::reflection_enabled_v<Base>, ReflectionImpl<Derived, Base>, Base> // See note above
+struct EnableFactory : public detail::EnableFactoryBase, public std::conditional_t<detail::reflection_enabled_v<Base>, ReflectionImpl<Derived, Base>, Base> // See note above
 {
     static_assert(std::is_base_of_v<InfoBase, Info<Derived>>, "Info<Derived> must inherit from InfoBase");
     static_assert(std::is_base_of_v<BuilderBase<Base>, Builder<Derived, Base>>, "Builder<Derived, Base> must inherit from BuilderBase<Base>");

--- a/include/core/factory.h
+++ b/include/core/factory.h
@@ -235,12 +235,12 @@ struct EnableReflection : public detail::EnableReflectionBase
 template<class Derived, class Base>
 struct ReflectionImpl : public Base
 {
-    TypeEnum GetType() const override
+    TypeEnum GetType() const final override
     {
-        static TypeEnum classType = Factory<Base>::template GetEnumFromType<Derived>();
+        static const TypeEnum classType = Factory<Base>::template GetEnumFromType<Derived>();
         return classType;
     }
-    Info<Base> const* GetInfo() const override
+    Info<Base> const* GetInfo() const final override
     {
         return Factory<Base>::GetInfo(GetType());
     }

--- a/include/core/generated_data.h
+++ b/include/core/generated_data.h
@@ -77,7 +77,7 @@ public:
     using DataEnum = typename ModuleGeneratedDataStorageDefault<ModuleClass>::DataEnum;
 };
 
-// Implements methods for the Module's generated data storage
+// Implements methods for the Module's generated data storage - should not be specialized
 template<class ModuleClass>
 class ModuleGeneratedDataMethods : public ModuleGeneratedDataStorage<ModuleClass>
 {
@@ -86,15 +86,14 @@ public:
     ModuleGeneratedDataMethods(ModuleClass const* moduleClass) : module_class_(moduleClass) {}
 
     using storage_t = ModuleGeneratedDataStorage<ModuleClass>;
-    using storage_default_t = typename ModuleGeneratedDataMethods<ModuleClass>::ModuleGeneratedDataStorageDefault<ModuleClass>;
-    static constexpr size_t data_count_ = storage_t::kCount;
+    static constexpr size_t data_count_ = storage_t::DataEnum::kCount;
 
-    const auto& GetState() const { return std::get<storage_t::kState>(storage_t::data_); }
-    auto& GetState() { return std::get<storage_t::kState>(storage_t::data_); }
+    const auto& GetState() const { return std::get<storage_t::DataEnum::kState>(storage_t::data_); }
+    auto& GetState() { return std::get<storage_t::DataEnum::kState>(storage_t::data_); }
 
-    template<typename storage_default_t::DataEnum I>
+    template<typename storage_t::DataEnum I>
     const auto& Get() const { return std::get<I>(storage_t::data_); }
-    template<typename storage_default_t::DataEnum I>
+    template<typename storage_t::DataEnum I>
     auto& Get() { return std::get<I>(storage_t::data_); }
 
     // Each Module implements their own

--- a/include/core/generated_data.h
+++ b/include/core/generated_data.h
@@ -1,0 +1,83 @@
+/*
+    generated_data.h
+    Written by Dalton Messmer <messmer.dalton@gmail.com>.
+
+    Defines ModuleGeneratedData
+*/
+
+#include "note.h"
+#include "data.h"
+#include "state.h"
+
+#include <cstddef>
+#include <unordered_map>
+
+namespace d2m {
+
+template<class ModuleClass>
+class ModuleGeneratedDataDefault
+{
+protected:
+    ModuleGeneratedDataDefault() = default;
+    virtual ~ModuleGeneratedDataDefault() = default;
+
+public:
+
+    // A unique identifier for wavetables, duty cycles, samples, etc.
+    using sound_index_t = size_t;
+
+    const ModuleState<ModuleClass>& GetState() const { return state_; }
+    ModuleState<ModuleClass>& GetState() { return state_; }
+
+    inline uint32_t GetPos(uint16_t order, uint16_t row) const { return (order << 16) | row; };
+    inline std::pair<order_index_t, row_index_t> GetPos(uint32_t pos) const { return { pos >> 16, pos & 0x00FF }; };
+
+private:
+    // Generated data storage
+
+    std::unordered_map<sound_index_t, std::pair<Note, Note>> sound_index_note_extremes_;
+    std::unordered_map<channel_index_t, std::pair<Note, Note>> channel_note_extremes_;
+
+    enum DataFlags : size_t
+    {
+        kSoundIndexNoteExtremes = 1,
+        kChannelNoteExtremes    = 2,
+        kNoteOffUsed            = 8,
+        kSoundIndexesUsed       = 32,
+        kDuplicateOrders        = 64,
+    };
+
+
+    /*
+     * Generated data for Module class A is intended to be used by Module classes B, C, and D
+     * which call methods on A's GeneratedData object to get the info they need for the conversion.
+     * Each type of generated data should be associated with a unique flag enum.
+     * These flag enums can be combined together by calling code to make a request for which
+     * generated data the calling code requires using the GeneratedData object's Generate method,
+     * and the GeneratedData object will return a flag enum indicating which data it was able to
+     * generate. This can be more efficient if the calling code does not need expensive data to be
+     * available. And some kinds of data can be efficiently obtained in the same big For loop.
+     * Could use if-constexpr to enable the collection of different data using the DataFlag template
+     * parameter. After the data is generated, getting it can be done with:
+     *     std::optional<DataFlagSpecificDataObject> data = Get<MyDataFlag>();
+     * If Generate was not called first (or there was an error calling it), the data associated with
+     * the data flag will be lazily calculated.
+     * 
+     * Again, a Module class's generated data will primarily be used by *other* Module classes.
+     * There is going to be generated data implemented by and calculated by class A which is only
+     * really useful to one other Module class B, but only A should have to know the details of how the
+     * information is calculated. This does feel less modular, but it the right thing to do as far as
+     * abstraction goes - which is more important. I can't be completely modular anyway, and it isn't
+     * super important - it's mainly to avoid any shotgun surgery anti-patterns.
+     */
+
+    ModuleState<ModuleClass> state_;
+
+};
+
+
+template<class ModuleClass>
+class ModuleGeneratedData : public ModuleGeneratedDataDefault<ModuleClass> {};
+
+
+} // namespace d2m

--- a/include/core/generated_data.h
+++ b/include/core/generated_data.h
@@ -174,30 +174,4 @@ struct GeneratedData : public GeneratedDataStorage<GeneratedDataCommonDefinition
     enum GenDataEnum {};
 };
 
-// This is used by Module classes
-template<class ModuleClass>
-class ModuleGeneratedData : public GeneratedData<ModuleClass>
-{
-private:
-
-    ModuleBase const* module_class_;
-
-public:
-
-    ModuleGeneratedData() = delete;
-    ModuleGeneratedData(ModuleBase const* moduleClass) : module_class_(moduleClass) {}
-
-    // Bring in dependencies from parent:
-    using typename GeneratedData<ModuleClass>::GenDataEnumCommon;
-    using typename GeneratedData<ModuleClass>::GenDataEnum;
-    //using typename GeneratedData<ModuleClass>::Parent;
-
-    size_t Generate(size_t dataFlags)
-    {
-        assert(module_class_);
-        return module_class_->GenerateDataImpl(dataFlags);
-    }
-
-};
-
 } // namespace d2m

--- a/include/core/generated_data.h
+++ b/include/core/generated_data.h
@@ -16,9 +16,6 @@
 
 namespace d2m {
 
-// A unique identifier for wavetables, duty cycles, samples, etc.
-using sound_index_t = size_t;
-
 template<class ModuleClass>
 class ModuleGeneratedDataStorageDefault
 {
@@ -28,7 +25,7 @@ protected:
 
 protected:
 
-    // All data types, wrapped with std::optional
+    // All data types, wrapped with std::optional (?)
     using state_t = std::optional<ModuleState<ModuleClass>>;
     using sound_index_note_extremes_t = std::optional<std::unordered_map<sound_index_t, std::pair<Note, Note>>>;
     using channel_note_extremes_t = std::optional<std::unordered_map<channel_index_t, std::pair<Note, Note>>>;
@@ -88,20 +85,17 @@ public:
     using storage_t = ModuleGeneratedDataStorage<ModuleClass>;
     static constexpr size_t data_count_ = static_cast<size_t>(storage_t::DataEnum::kCount);
 
-    const auto& GetState() const { return std::get<storage_t::DataEnum::kState>(storage_t::data_); }
-    auto& GetState() { return std::get<storage_t::DataEnum::kState>(storage_t::data_); }
+    const std::optional<ModuleState<ModuleClass>>& GetState() const { return std::get<(size_t)storage_t::DataEnum::kState>(storage_t::data_); }
+    std::optional<ModuleState<ModuleClass>>& GetState() { return std::get<(size_t)storage_t::DataEnum::kState>(storage_t::data_); }
 
     template<typename storage_t::DataEnum I>
-    const auto& Get() const { return std::get<I>(storage_t::data_); }
+    const auto& Get() const { return std::get<(size_t)I>(storage_t::data_); }
     template<typename storage_t::DataEnum I>
-    auto& Get() { return std::get<I>(storage_t::data_); }
+    auto& Get() { return std::get<(size_t)I>(storage_t::data_); }
 
     // Each Module implements their own
     template<size_t DataFlagsT>
     size_t Generate();
-
-    inline uint32_t GetPos(uint16_t order, uint16_t row) const { return (order << 16) | row; };
-    inline std::pair<order_index_t, row_index_t> GetPos(uint32_t pos) const { return { pos >> 16, pos & 0x00FF }; };
 
 private:
     ModuleClass const* module_class_;

--- a/include/core/generated_data.h
+++ b/include/core/generated_data.h
@@ -163,7 +163,7 @@ template<class ModuleClass>
 struct GeneratedData : public GeneratedDataStorage<GeneratedDataCommonDefinition<ModuleClass> /* Module-specific types go here in any specializations */>
 {
     //using Parent = GeneratedDataStorage<GeneratedDataCommonDefinition<ModuleClass>>;
-    using GeneratedDataCommonDefinition<ModuleClass>::GenDataEnumCommon;
+    using typename GeneratedDataCommonDefinition<ModuleClass>::GenDataEnumCommon;
     enum GenDataEnum {};
 };
 

--- a/include/core/generated_data.h
+++ b/include/core/generated_data.h
@@ -83,21 +83,6 @@ struct GeneratedDataCommonDefinition : public detail::GenDataDefinitionTag
         SoundIndexesUsedGenData<ModuleClass>,
         StateGenData<ModuleClass>
         >;
-
-    // Not necessary, but could be used for potential performance improvements when calling Generate()
-    //  by only generating the data which is needed.
-    enum GenDataFlagsCommon : size_t
-    {
-        kFlagAll                    = 0, // 0 as a template parameter to Generate() means calculate all generated data
-        kFlagState                  = 1,
-        kFlagSoundIndexesUsed       = 2,
-        kFlagSoundIndexNoteExtremes = 4,
-        kFlagChannelNoteExtremes    = 8,
-        kFlagLoopbackPoints         = 16,
-        kFlagNoteOffUsed            = 32,
-        kFlagDuplicateOrders        = 64
-        // ...
-    };
 };
 
 ///////////////////////////////////////////////////////////

--- a/include/core/generated_data.h
+++ b/include/core/generated_data.h
@@ -11,7 +11,7 @@
 #include "module_base.h"
 
 #include <cstddef>
-#include <unordered_map>
+#include <map>
 #include <set>
 #include <optional>
 #include <cassert>
@@ -45,27 +45,27 @@ using wrapped_gen_data_t = typename wrapped_gen_data<T...>::type;
 // COMMON GENERATED DATA TYPES
 ///////////////////////////////////////////////////////////
 
-// All data types, wrapped with std::optional (?)
-template<class T> using StateGenData = std::optional<ModuleState<T>>;
-using SoundIndexNoteExtremesGenData = std::optional<std::unordered_map<SoundIndex, std::pair<Note, Note>>>;
-using ChannelNoteExtremesGenData = std::optional<std::unordered_map<ChannelIndex, std::pair<Note, Note>>>;
-using NoteOffUsedGenData = std::optional<bool>;
-using SoundIndexesUsedGenData = std::optional<std::set<SoundIndex>>;
-using LoopbackPointsGenData = std::optional<std::map<OrderIndex, OrderRowPosition>>; // Jump destination order --> Order/Row where the PosJump occurred
+template<class T> using StateGenData = ModuleState<T>;
+template<class T> using SoundIndexNoteExtremesGenData = std::map<typename SoundIndex<T>::type, std::pair<Note, Note>>;
+using ChannelNoteExtremesGenData = std::map<ChannelIndex, std::pair<Note, Note>>;
+using NoteOffUsedGenData = bool;
+template<class T> using SoundIndexesUsedGenData = std::set<typename SoundIndex<T>::type>;
+using LoopbackPointsGenData = std::map<OrderIndex, OrderRowPosition>; // Jump destination order --> Order/Row where the PosJump occurred
 
 ///////////////////////////////////////////////////////////
 // COMMON GENERATED DATA DEFINITION
 ///////////////////////////////////////////////////////////
 
-template<class ModuleClass>
+template<class TModule>
 struct GeneratedDataCommonDefinition : public detail::GenDataDefinitionTag
 {
-    static constexpr int kCommonCount = 7; // # of variants in GenDataEnumCommon (remember to update this after changing the enum)
+    static constexpr int kCommonCount = 6; // # of variants in GenDataEnumCommon (remember to update this after changing the enum)
     static constexpr int kLowerBound = -kCommonCount;
+    using ModuleClass = TModule;
 
-    enum class GenDataEnumCommon
+    enum GenDataEnumCommon
     {
-        kDuplicateOrders        =-7,
+        //kDuplicateOrders        =-7,
         kNoteOffUsed            =-6,
         kLoopbackPoints         =-5,
         kChannelNoteExtremes    =-4,
@@ -74,13 +74,14 @@ struct GeneratedDataCommonDefinition : public detail::GenDataDefinitionTag
         kState                  =-1,
     };
 
+    // Lowest to highest
     using GenDataCommon = std::tuple<
-        StateGenData<ModuleClass>,
-        SoundIndexNoteExtremesGenData,
-        ChannelNoteExtremesGenData,
         NoteOffUsedGenData,
-        SoundIndexesUsedGenData,
-        LoopbackPointsGenData
+        LoopbackPointsGenData,
+        ChannelNoteExtremesGenData,
+        SoundIndexNoteExtremesGenData<ModuleClass>,
+        SoundIndexesUsedGenData<ModuleClass>,
+        StateGenData<ModuleClass>
         >;
 
     // Not necessary, but could be used for potential performance improvements when calling Generate()
@@ -110,6 +111,7 @@ public:
     static constexpr int kUpperBound = sizeof...(Ts); // # of module-specific gen data types
 
     using typename CommonDef::GenDataEnumCommon;
+    using typename CommonDef::ModuleClass;
 
     // The GenDataEnum for any module-specific types should be defined
     //  in the GeneratedData template specialization

--- a/include/core/generated_data.h
+++ b/include/core/generated_data.h
@@ -142,6 +142,13 @@ public:
     constexpr const std::optional<ModuleState<ModuleClass>>& GetState() const { return Get<GenDataEnumCommon::kState>(); }
     constexpr std::optional<ModuleState<ModuleClass>>& GetState() { return Get<GenDataEnumCommon::kState>(); }
 
+    // Destroys any generated data at index gen_data_index. Call this after any change which would make the data invalid.
+    template<int gen_data_index>
+    void Clear()
+    {
+        std::get<gen_data_index + CommonDef::kCommonCount>(data_).reset();
+    }
+
 protected:
     GenDataWrapped data_; // Stores all generated data
 };

--- a/include/core/generated_data.h
+++ b/include/core/generated_data.h
@@ -14,6 +14,7 @@
 #include <unordered_map>
 #include <set>
 #include <optional>
+#include <cassert>
 
 namespace d2m {
 
@@ -103,10 +104,10 @@ public:
     template<DataEnum I>
     auto& Get() { return std::get<(size_t)I>(data_); }
 
-    template<size_t DataFlagsT>
-    size_t Generate()
+    size_t Generate(size_t dataFlags)
     {
-        return module_class_->GenerateDataImpl(DataFlagsT);
+        assert(module_class_);
+        return module_class_->GenerateDataImpl(dataFlags);
     }
 };
 

--- a/include/core/generated_data.h
+++ b/include/core/generated_data.h
@@ -86,7 +86,7 @@ public:
     ModuleGeneratedDataMethods(ModuleClass const* moduleClass) : module_class_(moduleClass) {}
 
     using storage_t = ModuleGeneratedDataStorage<ModuleClass>;
-    static constexpr size_t data_count_ = storage_t::DataEnum::kCount;
+    static constexpr size_t data_count_ = static_cast<size_t>(storage_t::DataEnum::kCount);
 
     const auto& GetState() const { return std::get<storage_t::DataEnum::kState>(storage_t::data_); }
     auto& GetState() { return std::get<storage_t::DataEnum::kState>(storage_t::data_); }

--- a/include/core/generated_data.h
+++ b/include/core/generated_data.h
@@ -2,7 +2,7 @@
     generated_data.h
     Written by Dalton Messmer <messmer.dalton@gmail.com>.
 
-    Defines ModuleGeneratedData
+    Defines GeneratedData and related class templates
 */
 
 #include "note.h"
@@ -17,10 +17,6 @@
 #include <cassert>
 
 namespace d2m {
-
-// Forward declare
-class ModuleBase;
-
 
 namespace detail {
 
@@ -56,12 +52,12 @@ template<class T> using StateGenData = ModuleState<T>;
 // COMMON GENERATED DATA DEFINITION
 ///////////////////////////////////////////////////////////
 
-template<class TModule>
+template<class T>
 struct GeneratedDataCommonDefinition : public detail::GenDataDefinitionTag
 {
     static constexpr int kCommonCount = 6; // # of variants in GenDataEnumCommon (remember to update this after changing the enum)
     static constexpr int kLowerBound = -kCommonCount;
-    using ModuleClass = TModule;
+    using ModuleClass = T;
 
     enum GenDataEnumCommon
     {
@@ -150,17 +146,33 @@ public:
     template<int gen_data_index>
     void Clear()
     {
-        std::get<gen_data_index + CommonDef::kCommonCount>(data_).reset();
+        auto& data = std::get<gen_data_index + CommonDef::kCommonCount>(data_);
+        if (data.has_value())
+        {
+            data.reset();
+            generated_.reset();
+            status_ = 0;
+        }
     }
 
     // Destroys all generated data
     void ClearAll()
     {
         detail::ClearAllGenData<-CommonDef::kCommonCount, kUpperBound>(this);
+        generated_.reset();
+        status_ = 0;
     }
+
+    bool IsValid() const { return generated_.has_value(); }
+    std::optional<size_t> GetGenerated() const { return generated_; }
+    void SetGenerated(std::optional<size_t> val) { generated_ = val; }
+    size_t GetStatus() const { return status_; }
+    void SetStatus(size_t val) { status_ = val; }
 
 protected:
     GenDataWrapped data_; // Stores all generated data
+    std::optional<size_t> generated_; // The value passed to GenerateDataImpl. Has a value if gen data is valid.
+    size_t status_; // The value returned by GenerateDataImpl. Only valid if IsValid() == true.
 };
 
 ///////////////////////////////////////////////////////////

--- a/include/core/module.h
+++ b/include/core/module.h
@@ -32,7 +32,7 @@ public:
 
     inline const ModuleData<Derived>& GetData() const { return m_data; }
     inline const ModuleGlobalData<Derived>& GetGlobalData() const { return GetData().GlobalData(); }
-    inline const std::shared_ptr<GeneratedData<Derived>>& GetGeneratedData() const { return m_generated_data; }
+    inline std::shared_ptr<const GeneratedData<Derived>> GetGeneratedData() const { return m_generated_data; }
 
     const std::string& GetTitle() const override { return GetGlobalData().title; }
     const std::string& GetAuthor() const override { return GetGlobalData().author; }
@@ -43,7 +43,7 @@ protected:
 
     inline ModuleData<Derived>& GetData() { return m_data; }
     inline ModuleGlobalData<Derived>& GetGlobalData() { return GetData().GlobalData(); }
-    inline std::shared_ptr<GeneratedData<Derived>>& GetGeneratedData() { return m_generated_data; }
+    inline std::shared_ptr<GeneratedData<Derived>> GetGeneratedDataMut() const { return m_generated_data; }
 
 private:
 
@@ -52,7 +52,7 @@ private:
 
     // Information about a module file which must be calculated.
     // Cannot be stored directly because other Modules need to modify its contents without modifying the Module
-    std::shared_ptr<GeneratedData<Derived>> m_generated_data;
+    const std::shared_ptr<GeneratedData<Derived>> m_generated_data;
 };
 
 } // namespace d2m

--- a/include/core/module.h
+++ b/include/core/module.h
@@ -2,12 +2,13 @@
     module.h
     Written by Dalton Messmer <messmer.dalton@gmail.com>.
 
-    Defines an interface for modules.
+    Defines an interface for Modules.
     All module classes must inherit ModuleInterface.
 */
 
 #pragma once
 
+#include "module_base.h"
 #include "factory.h"
 #include "conversion_options.h"
 #include "status.h"
@@ -21,115 +22,6 @@
 
 namespace d2m {
 
-// Forward declares
-class ModuleBase;
-class ConversionOptionsBase;
-
-// Type aliases to make usage easier
-using Module = ModuleBase;
-using ModulePtr = std::shared_ptr<Module>;
-using ConversionOptions = ConversionOptionsBase;
-using ConversionOptionsPtr = std::shared_ptr<ConversionOptions>;
-
-// Specialized Info class for Modules
-template<>
-struct Info<ModuleBase> : public InfoBase
-{
-    std::string friendlyName{};
-    std::string fileExtension{};
-};
-
-
-// Base class for all module types (DMF, MOD, XM, etc.)
-class ModuleBase : public EnableReflection<ModuleBase>, public std::enable_shared_from_this<ModuleBase>
-{
-protected:
-
-    ModuleBase() = default;
-
-    // TODO: Use this
-    enum class ExportState
-    {
-        Empty, Invalid, Ready
-    };
-
-public:
-
-    virtual ~ModuleBase() = default;
-
-    /*
-     * Cast ModulePtr to std::shared_ptr<T> where T is the derived Module class
-     */
-    template<class T, std::enable_if_t<std::is_base_of_v<ModuleBase, T>, bool> = true>
-    std::shared_ptr<T> Cast() const
-    {
-        return std::static_pointer_cast<T>(shared_from_this());
-    }
-
-    /*
-     * Create and import a new module given a filename. Module type is inferred from the file extension.
-     * Returns pointer to the module or nullptr if a module registration error occurred.
-     */
-    static ModulePtr CreateAndImport(const std::string& filename);
-
-    /*
-     * Import the specified module file
-     * Returns true upon failure
-     */
-    bool Import(const std::string& filename);
-
-    /*
-     * Export module to the specified file
-     * Returns true upon failure
-     */
-    bool Export(const std::string& filename);
-
-    /*
-     * Converts the module to the specified type using the provided conversion options
-     */
-    ModulePtr Convert(ModuleType type, const ConversionOptionsPtr& options);
-
-    /*
-     * Gets the Status object for the last import/export/convert
-     */
-    const Status& GetStatus() const { return m_Status; }
-
-    /*
-     * Convenience wrapper for GetStatus().HandleResults()
-     */
-    bool HandleResults() const { return m_Status.HandleResults(); }
-
-    /*
-     * Get the title of the module
-     */
-    virtual std::string GetTitle() const = 0;
-
-    /*
-     * Get the author of the module
-     */
-    virtual std::string GetAuthor() const = 0;
-
-    ////////////////////////////////////////////////////////
-    // Methods for getting static info about module type  //
-    ////////////////////////////////////////////////////////
-
-protected:
-    // Import() and Export() and Convert() are wrappers for these methods, which must be implemented by a module class:
-
-    virtual void ImportRaw(const std::string& filename) = 0;
-    virtual void ExportRaw(const std::string& filename) = 0;
-    virtual void ConvertRaw(const ModulePtr& input) = 0;
-
-    ConversionOptionsPtr GetOptions() const { return m_Options; }
-
-    Status m_Status;
-
-private:
-
-    ConversionOptionsPtr m_Options;
-};
-
-
 // All module classes must derive from this using CRTP
 template<class Derived>
 class ModuleInterface : public EnableFactory<Derived, ModuleBase>
@@ -137,6 +29,8 @@ class ModuleInterface : public EnableFactory<Derived, ModuleBase>
 protected:
 
     ModuleInterface() : m_GeneratedData(std::make_shared<ModuleGeneratedData<Derived>>(static_cast<Derived const*>(this))) {}
+
+    friend ModuleGeneratedDataMethods<Derived>;
 
 public:
 

--- a/include/core/module.h
+++ b/include/core/module.h
@@ -26,35 +26,33 @@ namespace d2m {
 template<class Derived>
 class ModuleInterface : public EnableFactory<Derived, ModuleBase>
 {
-protected:
-
-    ModuleInterface() : m_GeneratedData(std::make_shared<ModuleGeneratedData<Derived>>(static_cast<Derived const*>(this))) {}
-
 public:
 
     virtual ~ModuleInterface() = default;
 
-    inline const ModuleData<Derived>& GetData() const { return m_Data; }
+    inline const ModuleData<Derived>& GetData() const { return m_data; }
     inline const ModuleGlobalData<Derived>& GetGlobalData() const { return GetData().GlobalData(); }
-    inline const std::shared_ptr<ModuleGeneratedData<Derived>>& GetGeneratedData() const { return m_GeneratedData; }
+    inline const std::shared_ptr<GeneratedData<Derived>>& GetGeneratedData() const { return m_generated_data; }
 
-    std::string GetTitle() const override { return GetGlobalData().title; }
-    std::string GetAuthor() const override { return GetGlobalData().author; }
+    const std::string& GetTitle() const override { return GetGlobalData().title; }
+    const std::string& GetAuthor() const override { return GetGlobalData().author; }
 
 protected:
 
-    inline ModuleData<Derived>& GetData() { return m_Data; }
+    ModuleInterface() : m_generated_data(std::make_shared<GeneratedData<Derived>>()) {}
+
+    inline ModuleData<Derived>& GetData() { return m_data; }
     inline ModuleGlobalData<Derived>& GetGlobalData() { return GetData().GlobalData(); }
-    inline std::shared_ptr<ModuleGeneratedData<Derived>>& GetGeneratedData() { return m_GeneratedData; }
+    inline std::shared_ptr<GeneratedData<Derived>>& GetGeneratedData() { return m_generated_data; }
 
 private:
 
     // Song information for a particular module file
-    ModuleData<Derived> m_Data;
+    ModuleData<Derived> m_data;
 
     // Information about a module file which must be calculated.
     // Cannot be stored directly because other Modules need to modify its contents without modifying the Module
-    std::shared_ptr<ModuleGeneratedData<Derived>> m_GeneratedData;
+    std::shared_ptr<GeneratedData<Derived>> m_generated_data;
 };
 
 } // namespace d2m

--- a/include/core/module.h
+++ b/include/core/module.h
@@ -30,8 +30,6 @@ protected:
 
     ModuleInterface() : m_GeneratedData(std::make_shared<ModuleGeneratedData<Derived>>(static_cast<Derived const*>(this))) {}
 
-    friend ModuleGeneratedDataMethods<Derived>;
-
 public:
 
     virtual ~ModuleInterface() = default;

--- a/include/core/module.h
+++ b/include/core/module.h
@@ -12,6 +12,7 @@
 #include "conversion_options.h"
 #include "status.h"
 #include "data.h"
+#include "generated_data.h"
 #include "note.h"
 #include "global_options.h"
 
@@ -140,6 +141,7 @@ public:
 
     inline const ModuleData<Derived>& GetData() const { return m_Data; }
     inline const ModuleGlobalData<Derived>& GetGlobalData() const { return GetData().GlobalData(); }
+    inline const ModuleGeneratedData<Derived>& GetGeneratedData() const { return m_GeneratedData; }
 
     std::string GetTitle() const override { return GetGlobalData().title; }
     std::string GetAuthor() const override { return GetGlobalData().author; }
@@ -148,10 +150,12 @@ protected:
 
     inline ModuleData<Derived>& GetData() { return m_Data; }
     inline ModuleGlobalData<Derived>& GetGlobalData() { return GetData().GlobalData(); }
+    inline ModuleGeneratedData<Derived>& GetGeneratedData() { return m_GeneratedData; }
 
 private:
 
     ModuleData<Derived> m_Data; // Song information for a particular module file
+    ModuleGeneratedData<Derived> m_GeneratedData; // Information about a module file which must be calculated
 };
 
 } // namespace d2m

--- a/include/core/module_base.h
+++ b/include/core/module_base.h
@@ -85,6 +85,11 @@ public:
     ModulePtr Convert(ModuleType type, const ConversionOptionsPtr& options);
 
     /*
+     * Generates the generated data using optional data flags
+     */
+    size_t GenerateData(size_t data_flags = 0) const { return GenerateDataImpl(data_flags); }
+
+    /*
      * Gets the Status object for the last import/export/convert
      */
     const Status& GetStatus() const { return m_Status; }
@@ -97,12 +102,12 @@ public:
     /*
      * Get the title of the module
      */
-    virtual std::string GetTitle() const = 0;
+    virtual const std::string& GetTitle() const = 0;
 
     /*
      * Get the author of the module
      */
-    virtual std::string GetAuthor() const = 0;
+    virtual const std::string& GetAuthor() const = 0;
 
 protected:
     // Import() and Export() and Convert() are wrappers for these methods, which must be implemented by a module class:

--- a/include/core/module_base.h
+++ b/include/core/module_base.h
@@ -1,0 +1,125 @@
+/*
+    module.h
+    Written by Dalton Messmer <messmer.dalton@gmail.com>.
+
+    Defines the base class for Modules.
+*/
+
+#pragma once
+
+#include "factory.h"
+#include "conversion_options.h"
+#include "status.h"
+
+#include <string>
+#include <memory>
+
+namespace d2m {
+
+// Forward declares
+class ModuleBase;
+class ConversionOptionsBase;
+
+// Type aliases to make usage easier
+using Module = ModuleBase;
+using ModulePtr = std::shared_ptr<Module>;
+using ConversionOptions = ConversionOptionsBase;
+using ConversionOptionsPtr = std::shared_ptr<ConversionOptions>;
+
+// Specialized Info class for Modules
+template<>
+struct Info<ModuleBase> : public InfoBase
+{
+    std::string friendlyName{};
+    std::string fileExtension{};
+};
+
+// Base class for all module types (DMF, MOD, XM, etc.)
+class ModuleBase : public EnableReflection<ModuleBase>, public std::enable_shared_from_this<ModuleBase>
+{
+protected:
+
+    ModuleBase() = default;
+
+    // TODO: Use this
+    enum class ExportState
+    {
+        Empty, Invalid, Ready
+    };
+
+public:
+
+    virtual ~ModuleBase() = default;
+
+    /*
+     * Cast ModulePtr to std::shared_ptr<T> where T is the derived Module class
+     */
+    template<class T, std::enable_if_t<std::is_base_of_v<ModuleBase, T>, bool> = true>
+    std::shared_ptr<T> Cast() const
+    {
+        return std::static_pointer_cast<T>(shared_from_this());
+    }
+
+    /*
+     * Create and import a new module given a filename. Module type is inferred from the file extension.
+     * Returns pointer to the module or nullptr if a module registration error occurred.
+     */
+    static ModulePtr CreateAndImport(const std::string& filename);
+
+    /*
+     * Import the specified module file
+     * Returns true upon failure
+     */
+    bool Import(const std::string& filename);
+
+    /*
+     * Export module to the specified file
+     * Returns true upon failure
+     */
+    bool Export(const std::string& filename);
+
+    /*
+     * Converts the module to the specified type using the provided conversion options
+     */
+    ModulePtr Convert(ModuleType type, const ConversionOptionsPtr& options);
+
+    /*
+     * Gets the Status object for the last import/export/convert
+     */
+    const Status& GetStatus() const { return m_Status; }
+
+    /*
+     * Convenience wrapper for GetStatus().HandleResults()
+     */
+    bool HandleResults() const { return m_Status.HandleResults(); }
+
+    /*
+     * Get the title of the module
+     */
+    virtual std::string GetTitle() const = 0;
+
+    /*
+     * Get the author of the module
+     */
+    virtual std::string GetAuthor() const = 0;
+
+protected:
+    // Import() and Export() and Convert() are wrappers for these methods, which must be implemented by a module class:
+
+    virtual void ImportImpl(const std::string& filename) = 0;
+    virtual void ExportImpl(const std::string& filename) = 0;
+    virtual void ConvertImpl(const ModulePtr& input) = 0;
+
+    // dataFlags specifies what data was requested to be generated
+    virtual size_t GenerateDataImpl(size_t dataFlags) const = 0;
+
+    ConversionOptionsPtr GetOptions() const { return m_Options; }
+
+    Status m_Status;
+
+private:
+
+    ConversionOptionsPtr m_Options;
+};
+
+} // namespace d2m

--- a/include/core/module_base.h
+++ b/include/core/module_base.h
@@ -120,7 +120,7 @@ protected:
     template<typename> friend class ModuleGeneratedData;
 
     // dataFlags specifies what data was requested to be generated
-    virtual size_t GenerateDataImpl(size_t dataFlags) const = 0;
+    virtual size_t GenerateDataImpl(size_t data_flags) const = 0;
 
     ConversionOptionsPtr GetOptions() const { return m_Options; }
 

--- a/include/core/module_base.h
+++ b/include/core/module_base.h
@@ -62,12 +62,6 @@ public:
     }
 
     /*
-     * Create and import a new module given a filename. Module type is inferred from the file extension.
-     * Returns pointer to the module or nullptr if a module registration error occurred.
-     */
-    static ModulePtr CreateAndImport(const std::string& filename);
-
-    /*
      * Import the specified module file
      * Returns true upon failure
      */

--- a/include/core/module_base.h
+++ b/include/core/module_base.h
@@ -19,6 +19,7 @@ namespace d2m {
 // Forward declares
 class ModuleBase;
 class ConversionOptionsBase;
+template<typename> class ModuleGeneratedData;
 
 // Type aliases to make usage easier
 using Module = ModuleBase;
@@ -109,6 +110,9 @@ protected:
     virtual void ImportImpl(const std::string& filename) = 0;
     virtual void ExportImpl(const std::string& filename) = 0;
     virtual void ConvertImpl(const ModulePtr& input) = 0;
+
+    // Allow ModuleGeneratedData to call GenerateDataImpl
+    template<typename> friend class ModuleGeneratedData;
 
     // dataFlags specifies what data was requested to be generated
     virtual size_t GenerateDataImpl(size_t dataFlags) const = 0;

--- a/include/core/module_base.h
+++ b/include/core/module_base.h
@@ -19,7 +19,6 @@ namespace d2m {
 // Forward declares
 class ModuleBase;
 class ConversionOptionsBase;
-template<typename> class ModuleGeneratedData;
 
 // Type aliases to make usage easier
 using Module = ModuleBase;
@@ -81,7 +80,7 @@ public:
     /*
      * Generates the generated data using optional data flags
      */
-    size_t GenerateData(size_t data_flags = 0) const { return GenerateDataImpl(data_flags); }
+    virtual size_t GenerateData(size_t data_flags = 0) const = 0;
 
     /*
      * Gets the Status object for the last import/export/convert
@@ -109,12 +108,6 @@ protected:
     virtual void ImportImpl(const std::string& filename) = 0;
     virtual void ExportImpl(const std::string& filename) = 0;
     virtual void ConvertImpl(const ModulePtr& input) = 0;
-
-    // Allow ModuleGeneratedData to call GenerateDataImpl
-    template<typename> friend class ModuleGeneratedData;
-
-    // dataFlags specifies what data was requested to be generated
-    virtual size_t GenerateDataImpl(size_t data_flags) const = 0;
 
     ConversionOptionsPtr GetOptions() const { return m_Options; }
 

--- a/include/core/note.h
+++ b/include/core/note.h
@@ -34,7 +34,7 @@ namespace NoteTypes
     enum { EmptyType, NoteType, OffType }; // The order is important
 
     struct Empty {};
-    constexpr inline bool operator==(const Empty&, const Empty&) { return true; };
+    inline constexpr bool operator==(const Empty&, const Empty&) { return true; };
 
     struct alignas(1) Note
     {
@@ -76,7 +76,7 @@ namespace NoteTypes
     };
 
     struct Off {};
-    constexpr inline bool operator==(const Off&, const Off&) { return true; };
+    inline constexpr bool operator==(const Off&, const Off&) { return true; };
 };
 
 using NoteSlot = std::variant<NoteTypes::Empty, NoteTypes::Note, NoteTypes::Off>;

--- a/include/core/note.h
+++ b/include/core/note.h
@@ -31,7 +31,7 @@ enum class NotePitch : uint8_t
 
 namespace NoteTypes
 {
-    enum { EmptyType, NoteType, OffType }; // The order is important
+    enum { kEmpty, kNote, kOff }; // The order is important
 
     struct Empty {};
     inline constexpr bool operator==(const Empty&, const Empty&) { return true; };
@@ -82,9 +82,9 @@ namespace NoteTypes
 using NoteSlot = std::variant<NoteTypes::Empty, NoteTypes::Note, NoteTypes::Off>;
 using Note = NoteTypes::Note; // For convenience
 
-inline constexpr bool NoteIsEmpty(const NoteSlot& note) { return note.index() == NoteTypes::EmptyType; }
-inline constexpr bool NoteHasPitch(const NoteSlot& note) { return note.index() == NoteTypes::NoteType; }
-inline constexpr bool NoteIsOff(const NoteSlot& note) { return note.index() == NoteTypes::OffType; }
+inline constexpr bool NoteIsEmpty(const NoteSlot& note) { return note.index() == NoteTypes::kEmpty; }
+inline constexpr bool NoteHasPitch(const NoteSlot& note) { return note.index() == NoteTypes::kNote; }
+inline constexpr bool NoteIsOff(const NoteSlot& note) { return note.index() == NoteTypes::kOff; }
 inline constexpr const Note& GetNote(const NoteSlot& note)
 {
     assert(NoteHasPitch(note) && "NoteSlot variant must be using the Note alternative");

--- a/include/core/note.h
+++ b/include/core/note.h
@@ -32,7 +32,10 @@ enum class NotePitch : uint8_t
 namespace NoteTypes
 {
     enum { EmptyType, NoteType, OffType }; // The order is important
+
     struct Empty {};
+    constexpr inline bool operator==(const Empty&, const Empty&) { return true; };
+
     struct alignas(1) Note
     {
         NotePitch pitch : 4;
@@ -71,7 +74,9 @@ namespace NoteTypes
             return this->octave != rhs.octave || this->pitch != rhs.pitch;
         }
     };
+
     struct Off {};
+    constexpr inline bool operator==(const Off&, const Off&) { return true; };
 };
 
 using NoteSlot = std::variant<NoteTypes::Empty, NoteTypes::Note, NoteTypes::Off>;

--- a/include/core/state.h
+++ b/include/core/state.h
@@ -243,14 +243,14 @@ private:
 template<class ModuleClass>
 struct GlobalState : public StateStorage<GlobalStateCommonDefinition<ModuleClass> /* Module-specific types go here in any specializations */>
 {
-    using GlobalStateCommonDefinition<ModuleClass>::StateEnumCommon;
+    using typename GlobalStateCommonDefinition<ModuleClass>::StateEnumCommon;
     enum StateEnum {};
 };
 
 template<class ModuleClass>
 struct ChannelState : public StateStorage<ChannelStateCommonDefinition<ModuleClass> /* Module-specific types go here in any specializations */>
 {
-    using ChannelStateCommonDefinition<ModuleClass>::StateEnumCommon;
+    using typename ChannelStateCommonDefinition<ModuleClass>::StateEnumCommon;
     enum StateEnum {};
 };
 
@@ -362,7 +362,7 @@ public:
     {
         StateData retVal;
         detail::CopyState<enum_lower_bound_, enum_upper_bound_>(this, retVal,
-            [this](auto& retValElem, const auto& val) constexpr
+            [](auto& retValElem, const auto& val) constexpr
         {
             retValElem = val;
         });

--- a/include/core/state.h
+++ b/include/core/state.h
@@ -256,12 +256,8 @@ public:
         return std::get<state_data_index + CommonDef::kCommonCount>(data_);
     }
 
-    constexpr const StateData& GetInitialState() const { return initial_state_; }
-    constexpr StateData& GetInitialState() { return initial_state_; }
-
 private:
     StateDataWrapped data_; // Stores all state data
-    StateData initial_state_; // Default values which are used when nothing is specified
 };
 
 template<class CommonDef, typename... Ts>
@@ -490,13 +486,6 @@ public:
         return true;
     }
 
-    // Gets the initial state
-    inline constexpr const StateData& GetInitialState() const
-    {
-        assert(state_);
-        return state_->GetInitialState();
-    }
-
     // Returns a tuple of all the state values at the current read position
     StateData Copy() const
     {
@@ -516,7 +505,7 @@ public:
      * If set_deltas == true, sets an array of bools specifying which state values have changed since last iteration.
      * These delta values can then be obtained by calling GetDeltas() or GetOneShotDeltas().
      */
-    template<bool set_deltas = false>
+    template<bool set_deltas = true>
     void SetReadPos(OrderRowPosition pos)
     {
         cur_pos_ = pos;
@@ -585,7 +574,7 @@ public:
      * If set_deltas == true, sets an array of bools specifying which state values have changed since last iteration.
      * These delta values can then be obtained by calling GetDeltas() or GetOneShotDeltas().
      */
-    template<bool set_deltas = false>
+    template<bool set_deltas = true>
     inline void SetReadPos(OrderIndex order, RowIndex row)
     {
         SetReadPos<set_deltas>(GetOrderRowPosition(order, row));
@@ -813,20 +802,6 @@ public:
     {
         get_oneshot_data_t<oneshot_data_index> val_copy = val;
         SetOneShot<oneshot_data_index>(std::move(val_copy));
-    }
-
-    // Sets the initial state
-    void SetInitialState(StateData&& vals)
-    {
-        assert(state_write_);
-        state_write_->GetInitialState() = std::move(vals);
-    }
-
-    // Sets the initial state
-    inline void SetInitialState(const StateData& vals)
-    {
-        StateData vals_copy = vals;
-        SetInitialState(std::move(vals_copy));
     }
 
     // Inserts state data at current position. Use with Copy() in order to "resume" a state.

--- a/include/core/state.h
+++ b/include/core/state.h
@@ -12,53 +12,185 @@
 #include <vector>
 #include <tuple>
 #include <array>
+#include <optional>
 #include <memory>
+#include <cstdint>
+#include <type_traits>
+
+#include "gcem.hpp"
 
 namespace d2m {
 
 // Unique, quickly calculated value encoding order # (not pattern #!) and pattern row #. Easily and quickly comparable.
-using global_pos_t = uint32_t;
+using pos_t = uint32_t;
 
-// Same as global_pos_t but on a per-channel basis
-using channel_pos_t = uint32_t;
+using global_pos_t = pos_t;
+using channel_pos_t = pos_t;
+
+// Helpers for conversion:
+inline constexpr pos_t GetPos(order_index_t order, row_index_t row) { return (order << 16) | row; };
+inline constexpr std::pair<order_index_t, row_index_t> GetPos(pos_t pos) { return { pos >> 16, pos & 0x00FF }; };
+
+namespace detail {
+
+struct state_definition_tag {};
+
+// Sourced from: https://stackoverflow.com/a/53398815/8704745
+template<typename... input_t>
+using tuple_cat_t = decltype(std::tuple_cat(std::declval<input_t>()...));
+
+/*
+template<typename T>
+struct wrapped_state_data
+{
+    using type = std::tuple<>;
+};
+
+template<typename T>
+using wrapped_state_data_t = typename wrapped_state_data<T>::type;
+*/
+
+template<typename T>
+struct wrapped_state_data {};
+
+template<typename... Ts>
+struct wrapped_state_data<std::tuple<Ts...>>
+{
+    // type is either an empty tuple or a tuple with each Ts wrapped in a vector of pairs
+    using type = std::conditional_t<sizeof...(Ts)==0, std::tuple<>, std::tuple<std::vector<std::pair<pos_t, Ts>>...>>;
+};
+
+template<typename... T>
+using wrapped_state_data_t = typename wrapped_state_data<T...>::type;
+
+} // namespace detail
 
 ///////////////////////////////////////////////////////////
 // COMMON STATE DATA TYPES
 ///////////////////////////////////////////////////////////
 
-struct TempoNode
+// A unique identifier for wavetables, duty cycles, samples, etc.
+using sound_index_t = size_t;
+
+using volume_t = uint16_t;
+using panning_t = int16_t;
+
+struct tempo_t
 {
     uint16_t num;
     uint16_t den;
 };
 
 ///////////////////////////////////////////////////////////
-// GLOBAL STATE
+// COMMON STATE DEFINITIONS
 ///////////////////////////////////////////////////////////
 
-// Global data that all modules are expected to implement. Specialize this to add supported global state data.
-template<class ModuleClass>
-class GlobalState
+struct GlobalStateCommonDefinition : public detail::state_definition_tag
 {
-    enum GlobalStateEnum
+    static constexpr int kCommonCount = 1; // # of variants in StateEnumCommon (remember to update this after changing the enum)
+    static constexpr int kLowerBound = -kCommonCount;
+
+    // Common state data have negative indexes
+    enum StateEnumCommon
     {
-        kCount=0 // count
+        kTempo=-1
     };
+
+    // Define common data types
+    using tempo_data_t = tempo_t;
+
+    // Lowest to highest
+    using common_data_t = std::tuple<
+        tempo_data_t
+        >;
+};
+
+struct ChannelStateCommonDefinition : public detail::state_definition_tag
+{
+    static constexpr int kCommonCount = 4; // # of variants in StateEnumCommon (remember to update this after changing the enum)
+    static constexpr int kLowerBound = -kCommonCount;
+
+    // Common state data have negative indexes
+    enum StateEnumCommon
+    {
+        kSoundIndex=-1,
+        kVolume=-2,
+        kNotePlaying=-3,
+        kPanning=-4
+    };
+
+    // Define common data types
+    using sound_index_data_t = sound_index_t;
+    using volume_data_t = volume_t;
+    using note_playing_data_t = bool;
+    using panning_data_t = panning_t;
+
+    // Lowest to highest
+    using common_data_t = std::tuple<
+        sound_index_data_t,
+        volume_data_t,
+        note_playing_data_t,
+        panning_data_t
+        >;
 };
 
 ///////////////////////////////////////////////////////////
-// PER-CHANNEL STATE
+// STATE STORAGE
 ///////////////////////////////////////////////////////////
 
-// Per-channel data that all modules are expected to implement. Specialize this to add supported per-channel state data.
-template<class ModuleClass>
-class ChannelState
+template<class CommonDefT, typename... Ts>
+class StateStorage : public CommonDefT
 {
-    enum ChannelStateEnum
+public:
+    static constexpr int kUpperBound = sizeof...(Ts); // # of module-specific state data types
+
+    // The StateEnum for any module-specific types should be defined
+    //  in the GlobalState template specialization
+
+    using module_specific_data_t = std::tuple<Ts...>;
+
+    // Single tuple of all data types stored by this state
+    using data_t = detail::tuple_cat_t<typename CommonDefT::common_data_t, module_specific_data_t>;
+
+    // Single tuple of all wrapped data types stored by this state. They should all be vectors of pairs.
+    using data_wrapped_t = detail::wrapped_state_data_t<data_t>;
+
+    // Returns an immutable reference to state data at index I
+    template<int I>
+    constexpr const auto& Get() const
     {
-        kCount=0 // count
-    };
+        return std::get<I + CommonDefT::kCommonCount>(data_);
+    }
+
+    /*
+    // Returns a mutable reference to state data at index I
+    template<int I>
+    constexpr auto& Get()
+    {
+        return std::get<I + CommonDefT::kCommonCount>(data_);
+    }
+    */
+
+private:
+    data_wrapped_t data_; // Stores all state data
 };
+
+///////////////////////////////////////////////////////////
+// GLOBAL/PER-CHANNEL STATE PRIMARY TEMPLATES
+///////////////////////////////////////////////////////////
+
+/*
+ * The following are the global and per-channel state storage primary class templates.
+ * They can be specialized to add additional supported state data if desired.
+ * Any specializations must inherit from StateStorage and pass the correct common definition
+ * struct plus the new module-specific types to the template parameter.
+ */
+
+template<class ModuleClass>
+struct GlobalState : public StateStorage<GlobalStateCommonDefinition /* Module-specific types go here in any specializations */> {};
+
+template<class ModuleClass>
+struct ChannelState : public StateStorage<ChannelStateCommonDefinition /* Module-specific types go here in any specializations */> {};
 
 ///////////////////////////////////////////////////////////
 // STATE READER
@@ -67,34 +199,43 @@ class ChannelState
 namespace detail {
 
 // Compile-time for loop adapted from: https://stackoverflow.com/a/55648874/8704745
-template<size_t start, class T, typename F, size_t... Is>
-void ctf_helper(T const* reader, F f, std::index_sequence<Is...>)
+template<int start, class T, typename F, size_t... Is>
+void next_state_ctf_helper(T const* reader, F f, std::index_sequence<Is...>)
 {
     (f(reader->template GetVec<start + Is>(), start + Is), ...);
 }
 
-template<size_t start, size_t end, class T, typename F>
-void compile_time_for(T const* reader, F f)
+template<int start, int end, class T, typename F>
+void next_state_ctf(T const* reader, F f)
 {
-    ctf_helper<start>(reader, f, std::make_index_sequence<end-start>{});
+    next_state_ctf_helper<start>(reader, f, std::make_index_sequence<gcem::abs(start) + end>{});
 }
-
-template<size_t I, class StateT>
-using state_vec_t = std::tuple_element_t<I, typename StateT::data_t>;
-
-template<size_t I, class StateT>
-using state_vec_elem_t = typename state_vec_t<I, StateT>::value_type;
-
-template<size_t I, class StateT>
-using state_data_t = typename state_vec_elem_t<I, StateT>::second_type;
 
 } // namespace detail
 
 
 // Allows easy, efficient reading/traversal of GlobalState/ChannelState
-template<class StateT>
+template<class StateT, std::enable_if_t<std::is_base_of_v<detail::state_definition_tag, StateT>, bool> = true>
 class StateReader
 {
+protected:
+
+    static constexpr int enum_lower_bound_ = StateT::kLowerBound;
+    static constexpr int enum_common_count_ = StateT::kCommonCount;
+    static constexpr int enum_upper_bound_ = StateT::kUpperBound;
+    static constexpr int enum_total_count_ = enum_common_count_ + enum_upper_bound_;
+
+public:
+
+    using state_data_t = typename StateT::data_t;
+    using state_data_wrapped_t = typename StateT::data_wrapped_t;
+
+    template<int I>
+    using get_data_t = std::tuple_element_t<I + enum_common_count_, state_data_t>;
+
+    template<int I>
+    using get_data_wrapped_t = std::tuple_element_t<I + enum_common_count_, state_data_wrapped_t>;
+
 public:
     StateReader(StateT const* state) : state_(state), cur_pos_(0), cur_indexes_{} {}
 
@@ -106,34 +247,34 @@ public:
     }
 
     // Get the specified state data (I) at the current index
-    template<size_t I>
-    const detail::state_data_t<I, StateT>& Get() const
+    template<int I>
+    constexpr const get_data_t<I>& Get() const
     {
         return GetVec<I>().at(cur_indexes_[I]).second;
     }
 
     // Get the specified state data (I) at the specified index (index)
-    template<size_t I>
-    const detail::state_data_t<I, StateT>& Get(size_t index) const
+    template<int I>
+    constexpr const get_data_t<I>& Get(size_t index) const
     {
         return GetVec<I>().at(index).second;
     }
 
     // Get the specified state data vector (I)
-    template<size_t I>
-    inline const detail::state_vec_t<I, StateT>& GetVec() const
+    template<int I>
+    inline constexpr const get_data_wrapped_t<I>& GetVec() const
     {
         return state_->template Get<I>();
     }
 
     // Advances read position to the next row in the state data; newPos should be the position after the last time this method was called.
-    void Next(uint32_t newPos)
+    void Next(pos_t newPos)
     {
         cur_pos_ = newPos;
 
-        detail::compile_time_for<0, enum_max_>(this, [this](const auto& vec, size_t N)
+        detail::next_state_ctf<enum_lower_bound_, enum_upper_bound_>(this, [this](const auto& vec, int N) constexpr
         {
-            size_t& index = cur_indexes_[N]; // Current index within state data for data type N
+            size_t& index = cur_indexes_[N + enum_common_count_]; // Current index within state data for data type N
             const size_t vec_size = vec.size();
 
             if (vec_size == 0 || index + 1 == vec_size)
@@ -148,18 +289,98 @@ public:
         });
     }
 
-private:
+    void Next(order_index_t order, row_index_t row)
+    {
+        Next(GetPos(order, row));
+    }
 
-    static constexpr int enum_max_ = StateT::kCount; // kCount is required to exist for every state data StateT
+protected:
 
     StateT const* state_; // The state this reader is reading from
     global_pos_t cur_pos_; // The current read position in terms of order and pattern row
-    std::array<size_t, enum_max_> cur_indexes_; // array of state data vector indexes
+    std::array<size_t, enum_total_count_> cur_indexes_; // array of state data vector indexes
+    // TODO: Add a "delta" array which keeps track of state data which recently changed
 };
 
 // Type aliases for convenience
 template<class T> using GlobalStateReader = StateReader<GlobalState<T>>;
 template<class T> using ChannelStateReader = StateReader<ChannelState<T>>;
+
+///////////////////////////////////////////////////////////
+// STATE READER/WRITER
+///////////////////////////////////////////////////////////
+
+namespace detail {
+
+// Compile-time for loop helper
+template<int start, class T, class Tuple, typename F, size_t... Is>
+void copy_state_ctf_helper(T const* reader, Tuple& t, F f, std::index_sequence<Is...>)
+{
+    (f(std::get<Is>(t), reader->template Get<start + Is>()), ...);
+}
+
+// Function F arguments are: (inner data tuple element reference, inner data)
+template<int start, int end, class T, class Tuple, typename F>
+void copy_state_ctf(T const* reader, Tuple& t, F f)
+{
+    copy_state_ctf_helper<start>(reader, t, f, std::make_index_sequence<gcem::abs(start) + end>{});
+}
+
+// Compile-time for loop helper
+template<int start, class T, class Tuple, typename F, size_t... Is>
+void insert_state_ctf_helper(T const* reader, Tuple& t, F f, std::index_sequence<Is...>)
+{
+    (f(reader->template GetVec<start + Is>(), std::get<Is>(t)), ...);
+}
+
+// Function F arguments are: (state data vector reference, inner data to insert)
+template<int start, int end, class T, class Tuple, typename F>
+void insert_state_ctf(T const* reader, Tuple& t, F f)
+{
+    insert_state_ctf_helper<start>(reader, t, f, std::make_index_sequence<gcem::abs(start) + end>{});
+}
+
+} // namespace detail
+
+template<class StateT>
+class StateReaderWriter : public StateReader<StateT>
+{
+public:
+
+    using StateReader<StateT>::StateReader;
+
+    using state_data_t = typename StateReader<StateT>::state_data_t;
+
+    state_data_t Copy() const
+    {
+        state_data_t retVal;
+        detail::copy_state_ctf<
+            StateReader<StateT>::enum_lower_bound_,
+            StateReader<StateT>::enum_upper_bound_>
+            (this, retVal, [this](auto& retValElem, const auto& val) constexpr
+        {
+            retValElem = val;
+        });
+        return retVal;
+    }
+
+    void Insert(state_data_t& allInnerData)
+    {
+        detail::insert_state_ctf<
+            StateReader<StateT>::enum_lower_bound_,
+            StateReader<StateT>::enum_upper_bound_>
+            (this, allInnerData, [this](auto& stateVec, auto& innerData) constexpr
+        {
+            // Create a (position, data) pair and add it to the end of the state vector
+            stateVec.push_back({StateReader<StateT>::cur_pos_, std::move(innerData)});
+        });
+    }
+
+};
+
+// Type aliases for convenience
+template<class T> using GlobalStateReaderWriter = StateReaderWriter<GlobalState<T>>;
+template<class T> using ChannelStateReaderWriter = StateReaderWriter<ChannelState<T>>;
 
 ///////////////////////////////////////////////////////////
 // MODULE STATE
@@ -179,6 +400,17 @@ public:
 
     // Creates and returns a ChannelStateReader for the given channel. The reader is valid only for as long as ModuleState is valid.
     std::shared_ptr<ChannelStateReader<ModuleClass>> GetChannelReader(channel_index_t channel) const { return std::make_shared<ChannelStateReader<ModuleClass>>(&channel_states_[channel]); }
+
+    // TODO: These methods should not be public:
+
+    // Creates and returns a GlobalStateReaderWriter. The reader/writer is valid only for as long as ModuleState is valid.
+    std::shared_ptr<GlobalStateReaderWriter<ModuleClass>> GetGlobalReaderWriter() const { return std::make_shared<GlobalStateReaderWriter<ModuleClass>>(&global_state_); }
+
+    // Creates and returns a ChannelStateReaderWriter for the given channel. The reader/writer is valid only for as long as ModuleState is valid.
+    std::shared_ptr<ChannelStateReaderWriter<ModuleClass>> GetChannelReaderWriter(channel_index_t channel) const { return std::make_shared<ChannelStateReaderWriter<ModuleClass>>(&channel_states_[channel]); }
+
+    GlobalState<ModuleClass>* GetGlobalState() { return global_state_; }
+    ChannelState<ModuleClass>* GetChannelState(channel_index_t channel) { return channel_states_[channel]; }
 
 private:
     GlobalState<ModuleClass> global_state_;

--- a/include/core/state.h
+++ b/include/core/state.h
@@ -1,0 +1,207 @@
+/*
+    states.h
+    Written by Dalton Messmer <messmer.dalton@gmail.com>.
+
+    Defines GlobalState, ChannelState, and StateReader
+*/
+
+#pragma once
+
+#include "config_types.h"
+
+#include <vector>
+#include <tuple>
+#include <array>
+
+namespace d2m {
+
+// Unique, quickly calculated value encoding order # (not pattern #!) and pattern row #. Easily and quickly comparable.
+using global_pos_t = uint32_t;
+
+// Same as global_pos_t but on a per-channel basis
+using channel_pos_t = uint32_t;
+
+///////////////////////////////////////////////////////////
+// COMMON STATE DATA TYPES
+///////////////////////////////////////////////////////////
+
+struct TempoNode
+{
+    uint16_t num;
+    uint16_t den;
+};
+
+///////////////////////////////////////////////////////////
+// GLOBAL STATE
+///////////////////////////////////////////////////////////
+
+// Global data that all modules are expected to implement. Specialize this to add supported global state data.
+template<ModuleType eT>
+class GlobalState
+{
+    enum GlobalStateEnum
+    {
+        kCount=0 // count
+    };
+};
+
+///////////////////////////////////////////////////////////
+// PER-CHANNEL STATE
+///////////////////////////////////////////////////////////
+
+// Per-channel data that all modules are expected to implement. Specialize this to add supported per-channel state data.
+template<ModuleType eT>
+class ChannelState
+{
+    enum ChannelStateEnum
+    {
+        kCount=0 // count
+    };
+};
+
+///////////////////////////////////////////////////////////
+// STATE READER
+///////////////////////////////////////////////////////////
+
+namespace detail {
+
+// Compile-time for loop adapted from: https://stackoverflow.com/a/55648874/8704745
+template<size_t start, class T, typename F, size_t... Is>
+void ctf_helper(T const* reader, F f, std::index_sequence<Is...>)
+{
+    (f(reader->template GetVec<start + Is>(), start + Is), ...);
+}
+
+template<size_t start, size_t end, class T, typename F>
+void compile_time_for(T const* reader, F f)
+{
+    ctf_helper<start>(reader, f, std::make_index_sequence<end-start>{});
+}
+
+template<size_t I, class StateT>
+using state_vec_t = std::tuple_element_t<I, typename StateT::data_t>;
+
+template<size_t I, class StateT>
+using state_vec_elem_t = typename state_vec_t<I, StateT>::value_type;
+
+template<size_t I, class StateT>
+using state_data_t = typename state_vec_elem_t<I, StateT>::second_type;
+
+} // namespace detail
+
+class StateReaderBase {};
+
+// Allows easy, efficient reading/traversal of GlobalState
+template<class StateT>
+class StateReader : public StateReaderBase
+{
+public:
+    StateReader(StateT const* state) : state_(state), cur_pos_(0), cur_indexes_{} {}
+
+    // Set current read position to the beginning of the Module's state data
+    void Reset()
+    {
+        cur_pos_ = 0;
+        cur_indexes_.fill(0);
+    }
+
+    // Get the specified state data (I) at the current index
+    template<size_t I>
+    const detail::state_data_t<I, StateT>& Get() const
+    {
+        return GetVec<I>().at(cur_indexes_[I]).second;
+    }
+
+    // Get the specified state data (I) at the specified index (index)
+    template<size_t I>
+    const detail::state_data_t<I, StateT>& Get(size_t index) const
+    {
+        return GetVec<I>().at(index).second;
+    }
+
+    // Get the specified state data vector (I)
+    template<size_t I>
+    inline const detail::state_vec_t<I, StateT>& GetVec() const
+    {
+        return state_->template Get<I>();
+    }
+
+    // Advances read position to the next row in the state data; newPos should be the position after the last time this method was called.
+    void Next(uint32_t newPos)
+    {
+        cur_pos_ = newPos;
+
+        detail::compile_time_for<0, enum_max_>(this, [this](const auto& vec, size_t N)
+        {
+            size_t& index = cur_indexes_[N]; // Current index within state data for data type N
+            const size_t vec_size = vec.size();
+
+            if (vec_size == 0 || index + 1 == vec_size)
+                return; // No state data for data type N, or on last element in state data
+
+            // There's a next state that we could potentially need to advance to
+            if (cur_pos_ >= vec.at(index+1).first)
+            {
+                // Need to advance
+                ++index;
+            }
+        });
+    }
+
+private:
+
+    static constexpr int enum_max_ = StateT::kCount; // kCount is required to exist for every state data StateT
+
+    StateT const* state_; // The state this reader is reading from
+    global_pos_t cur_pos_; // The current read position in terms of order and pattern row
+    std::array<size_t, enum_max_> cur_indexes_; // array of state data vector indexes
+};
+
+// Type aliases for convenience
+template<ModuleType eT> using GlobalStateReader = StateReader<GlobalState<eT>>;
+template<ModuleType eT> using ChannelStateReader = StateReader<ChannelState<eT>>;
+
+
+// Temporarily putting an implementation here for testing purposes:
+
+template<>
+class GlobalState<ModuleType::DMF>
+{
+public:
+    enum GlobalStateEnum
+    {
+        kTempo,
+        kCount // Required
+    };
+
+    using tempo_t = std::vector<std::pair<global_pos_t, TempoNode>>;
+
+    // A data_t tuple is required for every GlobalState/ChannelState specialization
+    // element indexes coorespond to GlobalStateEnum variants
+    using data_t = std::tuple<tempo_t>;
+
+    // Returns a mutable reference to state data at index I
+    template<size_t I>
+    detail::state_vec_t<I, GlobalState<ModuleType::DMF>>& GetMut()
+    {
+        if constexpr (I == kTempo)
+            return tempo_;
+        throw std::out_of_range{""};
+    }
+
+    // Returns an immutable reference to state data at index I
+    template<size_t I>
+    const detail::state_vec_t<I, GlobalState<ModuleType::DMF>>& Get() const
+    {
+        if constexpr (I == kTempo)
+            return tempo_;
+        throw std::out_of_range{""};
+    }
+
+private:
+
+    tempo_t tempo_;
+};
+
+
+} // namespace d2m

--- a/include/core/state.h
+++ b/include/core/state.h
@@ -25,7 +25,7 @@
 namespace d2m {
 
 // Unique, quickly calculated value encoding order # (not pattern #!) and pattern row #. Easily and quickly comparable.
-using OrderRowPosition = uint32_t;
+using OrderRowPosition = int32_t;
 
 using GlobalOrderRowPosition = OrderRowPosition;
 using ChannelOrderRowPosition = OrderRowPosition;

--- a/include/core/state.h
+++ b/include/core/state.h
@@ -18,6 +18,7 @@
 #include <memory>
 #include <cstdint>
 #include <type_traits>
+#include <functional>
 #include <cassert>
 
 #include "gcem.hpp"
@@ -628,6 +629,25 @@ public:
     static constexpr get_data_t<state_data_index> GetValue(const StateData& data)
     {
         return std::get<GetIndex(state_data_index)>(data);
+    }
+
+    template<int state_data_index>
+    constexpr auto Find(std::function<bool(const get_data_t<state_data_index>&)> cmp) const -> std::optional<std::pair<OrderRowPosition, get_data_t<state_data_index>>>
+    {
+        const auto& vec = GetVec<state_data_index>();
+        if (vec.empty())
+            return std::nullopt;
+
+        int vec_index = cur_indexes_[GetIndex(state_data_index)];
+        assert(vec_index >= 0 && "The initial state must be set before reading");
+        for (; vec_index < static_cast<int>(vec.size()); ++vec_index)
+        {
+            const auto& elem = vec.at(vec_index);
+            if (cmp(elem.second))
+                return elem;
+        }
+
+        return std::nullopt;
     }
 
 protected:

--- a/include/core/state.h
+++ b/include/core/state.h
@@ -90,11 +90,10 @@ using state_data_t = typename state_vec_elem_t<I, StateT>::second_type;
 
 } // namespace detail
 
-class StateReaderBase {};
 
-// Allows easy, efficient reading/traversal of GlobalState
+// Allows easy, efficient reading/traversal of GlobalState/ChannelState
 template<class StateT>
-class StateReader : public StateReaderBase
+class StateReader
 {
 public:
     StateReader(StateT const* state) : state_(state), cur_pos_(0), cur_indexes_{} {}
@@ -166,10 +165,8 @@ template<class T> using ChannelStateReader = StateReader<ChannelState<T>>;
 // MODULE STATE
 ///////////////////////////////////////////////////////////
 
-class ModuleStateBase {};
-
 template<class ModuleClass>
-class ModuleState : public ModuleStateBase
+class ModuleState
 {
 public:
     void Initialize(unsigned numChannels)
@@ -181,7 +178,7 @@ public:
     std::shared_ptr<GlobalStateReader<ModuleClass>> GetGlobalReader() const { return std::make_shared<GlobalStateReader<ModuleClass>>(&global_state_); }
 
     // Creates and returns a ChannelStateReader for the given channel. The reader is valid only for as long as ModuleState is valid.
-    std::shared_ptr<ChannelStateReader<ModuleClass>> GetChannelReader(unsigned channel) const { return std::make_shared<ChannelStateReader<ModuleClass>>(&channel_states_[channel]); }
+    std::shared_ptr<ChannelStateReader<ModuleClass>> GetChannelReader(channel_index_t channel) const { return std::make_shared<ChannelStateReader<ModuleClass>>(&channel_states_[channel]); }
 
 private:
     GlobalState<ModuleClass> global_state_;

--- a/include/core/state.h
+++ b/include/core/state.h
@@ -25,18 +25,18 @@
 namespace d2m {
 
 // Unique, quickly calculated value encoding order # (not pattern #!) and pattern row #. Easily and quickly comparable.
-using pos_t = uint32_t;
+using OrderRowPosition = uint32_t;
 
-using global_pos_t = pos_t;
-using channel_pos_t = pos_t;
+using GlobalOrderRowPosition = OrderRowPosition;
+using ChannelOrderRowPosition = OrderRowPosition;
 
 // Helpers for conversion:
-inline constexpr pos_t GetPos(order_index_t order, row_index_t row) { return (order << 16) | row; };
-inline constexpr std::pair<order_index_t, row_index_t> GetPos(pos_t pos) { return { pos >> 16, pos & 0x00FF }; };
+inline constexpr OrderRowPosition GetOrderRowPosition(OrderIndex order, RowIndex row) { return (order << 16) | row; };
+inline constexpr std::pair<OrderIndex, RowIndex> GetOrderRowPosition(OrderRowPosition pos) { return { pos >> 16, pos & 0x00FF }; };
 
 namespace detail {
 
-struct state_definition_tag {};
+struct StateDefinitionTag {};
 
 // Sourced from: https://stackoverflow.com/a/53398815/8704745
 template<typename... input_t>
@@ -49,7 +49,7 @@ template<typename... Ts>
 struct wrapped_state_data<std::tuple<Ts...>>
 {
     // type is either an empty tuple or a tuple with each Ts wrapped in a vector of pairs
-    using type = std::conditional_t<sizeof...(Ts)==0, std::tuple<>, std::tuple<std::vector<std::pair<pos_t, Ts>>...>>;
+    using type = std::conditional_t<sizeof...(Ts)==0, std::tuple<>, std::tuple<std::vector<std::pair<OrderRowPosition, Ts>>...>>;
 };
 
 template<typename... T>
@@ -62,24 +62,50 @@ using wrapped_state_data_t = typename wrapped_state_data<T...>::type;
 ///////////////////////////////////////////////////////////
 
 // A unique identifier for wavetables, duty cycles, samples, etc.
-using sound_index_t = size_t;
+using SoundIndex = size_t;
 
-using effect_val_xx_t = uint8_t;
-using effect_val_xxyy_t = std::pair<uint8_t, uint8_t>;
+using EffectValueXX = uint8_t;
+using EffectValueXXYY = std::pair<uint8_t, uint8_t>;
 
-struct port_t
+// Global state data types
+
+using TempoStateData = EffectValueXX;
+using SpeedAStateData = EffectValueXX;
+using SpeedBStateData = EffectValueXX;
+using PatBreakStateData = EffectValueXX;
+using PosJumpStateData = EffectValueXX;
+
+// Per-channel state data types
+
+using NoteDelayStateData = EffectValueXX;
+using NoteCutStateData = EffectValueXX;
+using RetriggerStateData = EffectValueXXYY;
+using VolSlideStateData = EffectValueXXYY;
+using PanningStateData = EffectValueXX;
+using TremoloStateData = EffectValueXXYY;
+using VibratoVolSlideStateData = EffectValueXXYY;
+using Port2NoteVolSlideStateData = EffectValueXXYY;
+using VibratoStateData = EffectValueXXYY;
+
+struct PortamentoStateData
 {
-    enum Type { Up, Down, ToNote } type;
-    effect_val_xx_t value;
+    enum Type { None, Up, Down, ToNote } type;
+    EffectValueXX value;
 };
 
-constexpr inline bool operator==(const port_t& lhs, const port_t& rhs) { return lhs.type == rhs.type && lhs.value == rhs.value; }
+// All state data types must have an equal-to operator defined for them
+inline constexpr bool operator==(const PortamentoStateData& lhs, const PortamentoStateData& rhs) { return lhs.type == rhs.type && lhs.value == rhs.value; }
+
+using ArpStateData = EffectValueXXYY;
+using VolumeStateData = EffectValueXX;
+using NoteSlotStateData = NoteSlot;
+using SoundIndexStateData = SoundIndex;
 
 ///////////////////////////////////////////////////////////
 // COMMON STATE DEFINITIONS
 ///////////////////////////////////////////////////////////
 
-struct GlobalStateCommonDefinition : public detail::state_definition_tag
+struct GlobalStateCommonDefinition : public detail::StateDefinitionTag
 {
     static constexpr int kCommonCount = 5; // # of variants in StateEnumCommon (remember to update this after changing the enum)
     static constexpr int kLowerBound = -kCommonCount;
@@ -88,32 +114,25 @@ struct GlobalStateCommonDefinition : public detail::state_definition_tag
     enum StateEnumCommon
     {
         // Add additional variants here
-        kJumpDestination    =-5,
-        kTempo              =-4,
-        kSpeed              =-3,
+        kTempo              =-5,
+        kSpeedB             =-4,
+        kSpeedA             =-3,
         kPatBreak           =-2,
         kPosJump            =-1
         // StateEnum contains values >= 0
     };
 
-    // Define common data types
-    using jump_dest_data_t = bool;
-    using tempo_data_t = effect_val_xx_t;
-    using speed_data_t = effect_val_xx_t;
-    using patbreak_data_t = effect_val_xx_t;
-    using posjump_data_t = effect_val_xx_t;
-
     // Lowest to highest
-    using common_data_t = std::tuple<
-        jump_dest_data_t,
-        tempo_data_t,
-        speed_data_t,
-        patbreak_data_t,
-        posjump_data_t
+    using StateDataCommon = std::tuple<
+        TempoStateData,
+        SpeedBStateData,
+        SpeedAStateData,
+        PatBreakStateData,
+        PosJumpStateData
         >;
 };
 
-struct ChannelStateCommonDefinition : public detail::state_definition_tag
+struct ChannelStateCommonDefinition : public detail::StateDefinitionTag
 {
     static constexpr int kCommonCount = 14; // # of variants in StateEnumCommon (remember to update this after changing the enum)
     static constexpr int kLowerBound = -kCommonCount;
@@ -139,38 +158,22 @@ struct ChannelStateCommonDefinition : public detail::state_definition_tag
         // StateEnum contains values >= 0
     };
 
-    // Define common data types
-    using notedelay_data_t = effect_val_xx_t;
-    using notecut_data_t = effect_val_xx_t;
-    using retrigger_data_t = effect_val_xxyy_t;
-    using volslide_data_t = effect_val_xxyy_t;
-    using panning_data_t = effect_val_xx_t;
-    using tremolo_data_t = effect_val_xxyy_t;
-    using vibrato_volslide_data_t = effect_val_xxyy_t;
-    using port2note_volslide_data_t = effect_val_xxyy_t;
-    using vibrato_data_t = effect_val_xxyy_t;
-    using port_data_t = port_t;
-    using arp_data_t = effect_val_xxyy_t;
-    using volume_data_t = effect_val_xx_t;
-    using noteslot_data_t = NoteSlot;
-    using sound_index_data_t = sound_index_t;
-
     // Lowest to highest
-    using common_data_t = std::tuple<
-        notedelay_data_t,
-        notecut_data_t,
-        retrigger_data_t,
-        volslide_data_t,
-        panning_data_t,
-        tremolo_data_t,
-        vibrato_volslide_data_t,
-        port2note_volslide_data_t,
-        vibrato_data_t,
-        port_data_t,
-        arp_data_t,
-        volume_data_t,
-        noteslot_data_t,
-        sound_index_data_t
+    using StateDataCommon = std::tuple<
+        NoteDelayStateData,
+        NoteCutStateData,
+        RetriggerStateData,
+        VolSlideStateData,
+        PanningStateData,
+        TremoloStateData,
+        VibratoVolSlideStateData,
+        Port2NoteVolSlideStateData,
+        VibratoStateData,
+        PortamentoStateData,
+        ArpStateData,
+        VolumeStateData,
+        NoteSlotStateData,
+        SoundIndexStateData
         >;
 };
 
@@ -178,43 +181,43 @@ struct ChannelStateCommonDefinition : public detail::state_definition_tag
 // STATE STORAGE
 ///////////////////////////////////////////////////////////
 
-template<class CommonDefT, typename... Ts>
-class StateStorage : public CommonDefT
+template<class CommonDef, typename... Ts>
+class StateStorage : public CommonDef
 {
 public:
     static constexpr int kUpperBound = sizeof...(Ts); // # of module-specific state data types
 
     // The StateEnum for any module-specific types should be defined
-    //  in the GlobalState template specialization
+    //  in the GlobalState/ChannelState template specialization
 
-    using module_specific_data_t = std::tuple<Ts...>;
+    using StateDataModuleSpecific = std::tuple<Ts...>;
 
     // Single tuple of all data types stored by this state
-    using data_t = detail::tuple_cat_t<typename CommonDefT::common_data_t, module_specific_data_t>;
+    using StateData = detail::tuple_cat_t<typename CommonDef::StateDataCommon, StateDataModuleSpecific>;
 
     // Single tuple of all wrapped data types stored by this state. They should all be vectors of pairs.
-    using data_wrapped_t = detail::wrapped_state_data_t<data_t>;
+    using StateDataWrapped = detail::wrapped_state_data_t<StateData>;
 
-    // Returns an immutable reference to state data at index I
-    template<int I>
+    // Returns an immutable reference to state data at index state_data_index
+    template<int state_data_index>
     constexpr const auto& Get() const
     {
-        return std::get<I + CommonDefT::kCommonCount>(data_);
+        return std::get<state_data_index + CommonDef::kCommonCount>(data_);
     }
 
-    // Returns a mutable reference to state data at index I
-    template<int I>
+    // Returns a mutable reference to state data at index state_data_index
+    template<int state_data_index>
     constexpr auto& Get()
     {
-        return std::get<I + CommonDefT::kCommonCount>(data_);
+        return std::get<state_data_index + CommonDef::kCommonCount>(data_);
     }
 
-    constexpr const data_t& GetInitialState() const { return initial_state_; }
-    constexpr data_t& GetInitialState() { return initial_state_; }
+    constexpr const StateData& GetInitialState() const { return initial_state_; }
+    constexpr StateData& GetInitialState() { return initial_state_; }
 
 private:
-    data_wrapped_t data_; // Stores all state data
-    data_t initial_state_; // Default values which are used when nothing is specified
+    StateDataWrapped data_; // Stores all state data
+    StateData initial_state_; // Default values which are used when nothing is specified
 };
 
 ///////////////////////////////////////////////////////////
@@ -227,6 +230,7 @@ private:
  * Any specializations must inherit from StateStorage and pass the correct common definition
  * struct plus the new module-specific types to the template parameter.
  * In addition, specializations must define StateEnumCommon and StateEnum.
+ * All state data types must have a "==" operator defined for them.
  */
 
 template<class ModuleClass>
@@ -250,63 +254,63 @@ struct ChannelState : public StateStorage<ChannelStateCommonDefinition /* Module
 namespace detail {
 
 // Compile-time for loop helper
-template<int start, class T, class Tuple, typename F, int... Is>
-void copy_state_ctf_helper(T const* reader, Tuple& t, F f, std::integer_sequence<int, Is...>)
+template<int start, class TReader, class TTuple, typename TFunction, int... Is>
+void CopyStateHelper(TReader const* reader, TTuple& t, TFunction f, std::integer_sequence<int, Is...>)
 {
     (f(std::get<Is>(t), reader->template Get<start + Is>()), ...);
 }
 
 // Function F arguments are: (inner data tuple element reference, inner data)
-template<int start, int end, class T, class Tuple, typename F>
-void copy_state_ctf(T const* reader, Tuple& t, F f)
+template<int start, int end, class TReader, class TTuple, typename TFunction>
+void CopyState(TReader const* reader, TTuple& t, TFunction f)
 {
-    copy_state_ctf_helper<start>(reader, t, f, std::make_integer_sequence<int, gcem::abs(start) + end>{});
+    CopyStateHelper<start>(reader, t, f, std::make_integer_sequence<int, gcem::abs(start) + end>{});
 }
 
 // Compile-time for loop helper
-template<int start, class T, typename F, int... Is>
-void next_state_ctf_helper(T const* reader, F f, std::integer_sequence<int, Is...>)
+template<int start, class Reader, typename Function, int... Is>
+void NextStateHelper(Reader const* reader, Function f, std::integer_sequence<int, Is...>)
 {
     (f(reader->template GetVec<start + Is>(), start + Is), ...);
 }
 
 // Function F arguments are: (wrapped state data vector, index)
-template<int start, int end, class T, typename F>
-void next_state_ctf(T const* reader, F f)
+template<int start, int end, class Reader, typename Function>
+void NextState(Reader const* reader, Function f)
 {
-    next_state_ctf_helper<start>(reader, f, std::make_integer_sequence<int, gcem::abs(start) + end>{});
+    NextStateHelper<start>(reader, f, std::make_integer_sequence<int, gcem::abs(start) + end>{});
 }
 
 } // namespace detail
 
 
 // Allows easy, efficient reading/traversal of GlobalState/ChannelState
-template<class StateT, std::enable_if_t<std::is_base_of_v<detail::state_definition_tag, StateT>, bool> = true>
+template<class TState, std::enable_if_t<std::is_base_of_v<detail::StateDefinitionTag, TState>, bool> = true>
 class StateReader
 {
 protected:
 
-    static constexpr int enum_lower_bound_ = StateT::kLowerBound;
-    static constexpr int enum_common_count_ = StateT::kCommonCount;
-    static constexpr int enum_upper_bound_ = StateT::kUpperBound;
+    static constexpr int enum_lower_bound_ = TState::kLowerBound;
+    static constexpr int enum_common_count_ = TState::kCommonCount;
+    static constexpr int enum_upper_bound_ = TState::kUpperBound;
     static constexpr int enum_total_count_ = enum_common_count_ + enum_upper_bound_;
 
 public:
 
     // Bring in dependencies:
-    using data_t = typename StateT::data_t;
-    using data_wrapped_t = typename StateT::data_wrapped_t;
-    using StateEnumCommon = typename StateT::StateEnumCommon;
-    using StateEnum = typename StateT::StateEnum;
+    using StateData = typename TState::StateData;
+    using StateDataWrapped = typename TState::StateDataWrapped;
+    using StateEnumCommon = typename TState::StateEnumCommon;
+    using StateEnum = typename TState::StateEnum;
 
     // Helpers:
-    template<int I> using get_data_t = std::tuple_element_t<I + enum_common_count_, data_t>;
-    template<int I> using get_data_wrapped_t = std::tuple_element_t<I + enum_common_count_, data_wrapped_t>;
+    template<int state_data_index> using get_data_t = std::tuple_element_t<state_data_index + enum_common_count_, StateData>;
+    template<int state_data_index> using get_data_wrapped_t = std::tuple_element_t<state_data_index + enum_common_count_, StateDataWrapped>;
 
 public:
     StateReader() : state_(nullptr), cur_pos_(0), cur_indexes_{} {}
-    StateReader(StateT* state) : state_(state), cur_pos_(0), cur_indexes_{} {}
-    void AssignState(StateT* state) { state_ = state; }
+    StateReader(TState* state) : state_(state), cur_pos_(0), cur_indexes_{} {}
+    void AssignState(TState* state) { state_ = state; }
 
     // Set current read position to the beginning of the Module's state data
     void Reset()
@@ -315,40 +319,40 @@ public:
         cur_indexes_.fill(0);
     }
 
-    // Get the specified state data (I) at the current read position
-    template<int I>
-    inline constexpr const get_data_t<I>& Get() const
+    // Get the specified state data (state_data_index) at the current read position
+    template<int state_data_index>
+    inline constexpr const get_data_t<state_data_index>& Get() const
     {
-        return GetVec<I>().at(cur_indexes_[I]).second;
+        return GetVec<state_data_index>().at(cur_indexes_[state_data_index]).second;
     }
 
-    // Get the specified state data (I) at the specified read index (index)
-    template<int I>
-    inline constexpr const get_data_t<I>& Get(size_t index) const
+    // Get the specified state data (state_data_index) at the specified read index (pos_index)
+    template<int state_data_index>
+    inline constexpr const get_data_t<state_data_index>& Get(size_t pos_index) const
     {
-        return GetVec<I>().at(index).second;
+        return GetVec<state_data_index>().at(pos_index).second;
     }
 
-    // Get the specified state data vector (I)
-    template<int I>
-    inline constexpr const get_data_wrapped_t<I>& GetVec() const
+    // Get the specified state data vector (state_data_index)
+    template<int state_data_index>
+    inline constexpr const get_data_wrapped_t<state_data_index>& GetVec() const
     {
         assert(state_);
-        return state_->template Get<I>();
+        return state_->template Get<state_data_index>();
     }
 
     // Gets the initial state
-    inline constexpr const data_t& GetInitialState() const
+    inline constexpr const StateData& GetInitialState() const
     {
         assert(state_);
         return state_->GetInitialState();
     }
 
     // Returns a tuple of all the state values at the current read position
-    data_t Copy() const
+    StateData Copy() const
     {
-        data_t retVal;
-        detail::copy_state_ctf<enum_lower_bound_, enum_upper_bound_>(this, retVal,
+        StateData retVal;
+        detail::CopyState<enum_lower_bound_, enum_upper_bound_>(this, retVal,
             [this](auto& retValElem, const auto& val) constexpr
         {
             retValElem = val;
@@ -359,22 +363,22 @@ public:
     /*
      * Advances the read position to the next row in the state data if needed; pos should be the current position.
      * Call this method at the start of an inner loop before any the reading has been done for that iteration.
-     * If ReturnDeltas == true, returns an array of bools specifying which state values have changed since last iteration.
+     * If return_deltas == true, returns an array of bools specifying which state values have changed since last iteration.
      */
-    template<bool ReturnDeltas = false>
-    std::conditional_t<ReturnDeltas, std::array<bool, enum_total_count_>, void> SetReadPos(pos_t pos)
+    template<bool return_deltas = false>
+    auto SetReadPos(OrderRowPosition pos) -> std::conditional_t<return_deltas, std::array<bool, enum_total_count_>, void>
     {
         cur_pos_ = pos;
 
-        [[maybe_unused]] std::array<bool, enum_total_count_> deltas{}; // Will probably be optimized away if returnDeltas == false
+        [[maybe_unused]] std::array<bool, enum_total_count_> deltas{}; // Will probably be optimized away if return_deltas == false
 
-        detail::next_state_ctf<enum_lower_bound_, enum_upper_bound_>(this, [&, this](const auto& vec, int N) constexpr
+        detail::NextState<enum_lower_bound_, enum_upper_bound_>(this, [&, this](const auto& vec, int state_data_index) constexpr
         {
-            size_t& index = cur_indexes_[N + enum_common_count_]; // Current index within state data for data type N
+            size_t& index = cur_indexes_[state_data_index + enum_common_count_]; // Current index within state data
             const size_t vecSize = vec.size();
 
             if (vecSize == 0 || index + 1 == vecSize)
-                return; // No state data for data type N, or on last element in state data
+                return; // No state data for data type state_data_index, or on last element in state data
 
             // There's a next state that we could potentially need to advance to
             if (cur_pos_ >= vec.at(index+1).first)
@@ -382,15 +386,15 @@ public:
                 // Need to advance
                 ++index;
 
-                if constexpr (ReturnDeltas)
+                if constexpr (return_deltas)
                 {
-                    // NOTE: If Set() is called with IgnoreDuplicates == true, delta could be true even if nothing changed.
-                    deltas[N + enum_common_count_] = true;
+                    // NOTE: If Set() is called with ignore_duplicates == true, delta could be true even if nothing changed.
+                    deltas[state_data_index + enum_common_count_] = true;
                 }
             }
         });
 
-        if constexpr (ReturnDeltas)
+        if constexpr (return_deltas)
             return deltas;
         else
             return;
@@ -399,15 +403,15 @@ public:
     /*
      * Advances the read position to the next row in the state data if needed; pos should be the current position.
      * Call this method at the start of an inner loop before any the reading has been done for that iteration.
-     * If ReturnDeltas == true, returns an array of bools specifying which state values have changed since last iteration.
+     * If return_deltas == true, returns an array of bools specifying which state values have changed since last iteration.
      */
-    template<bool ReturnDeltas = false>
-    inline std::conditional_t<ReturnDeltas, std::array<bool, enum_total_count_>, void> SetReadPos(order_index_t order, row_index_t row)
+    template<bool return_deltas = false>
+    inline auto SetReadPos(OrderIndex order, RowIndex row) -> std::conditional_t<return_deltas, std::array<bool, enum_total_count_>, void>
     {
-        if constexpr (ReturnDeltas)
-            return SetReadPos<ReturnDeltas>(GetPos(order, row));
+        if constexpr (return_deltas)
+            return SetReadPos<return_deltas>(GetOrderRowPosition(order, row));
         else
-            SetReadPos<ReturnDeltas>(GetPos(order, row));
+            SetReadPos<return_deltas>(GetOrderRowPosition(order, row));
     }
 
     // Add this value to StateEnumCommon or StateEnum variants to get a zero-based index into an array such as the one returned by SetReadPos
@@ -415,8 +419,8 @@ public:
 
 protected:
 
-    StateT* state_; // The state this reader is reading from
-    pos_t cur_pos_; // The current read position in terms of order and pattern row. (The write position is the end of the state data vector)
+    TState* state_; // The state this reader is reading from
+    OrderRowPosition cur_pos_; // The current read position in terms of order and pattern row. (The write position is the end of the state data vector)
     std::array<size_t, enum_total_count_> cur_indexes_; // array of state data vector indexes
 };
 
@@ -431,17 +435,17 @@ template<class T> using ChannelStateReader = StateReader<ChannelState<T>>;
 namespace detail {
 
 // Compile-time for loop helper
-template<int start, class T, class Tuple, int... Is>
-void insert_state_ctf_helper(T* writer, const Tuple& t, std::integer_sequence<int, Is...>)
+template<int start, class TWriter, class TTuple, int... Is>
+void InsertStateHelper(TWriter* writer, const TTuple& t, std::integer_sequence<int, Is...>)
 {
     (writer->template Set<start + Is>(std::get<Is>(t)), ...);
 }
 
 // Calls writer->Set() for each element in the tuple t
-template<int start, int end, class T, class Tuple>
-void insert_state_ctf(T* writer, const Tuple& t)
+template<int start, int end, class TWriter, class TTuple>
+void InsertState(TWriter* writer, const TTuple& t)
 {
-    insert_state_ctf_helper<start>(writer, t, std::make_integer_sequence<int, gcem::abs(start) + end>{});
+    InsertStateHelper<start>(writer, t, std::make_integer_sequence<int, gcem::abs(start) + end>{});
 }
 
 template<typename T>
@@ -458,48 +462,48 @@ template<typename... T>
 using optional_state_data_t = typename optional_state_data<T...>::type;
 
 // Compile-time for loop helper
-template<int start, class T, class Tuple, int... Is>
-void optional_insert_state_ctf_helper(T* writer, const Tuple& t, std::integer_sequence<int, Is...>)
+template<int start, class TWriter, class TTuple, int... Is>
+void InsertStateOptionalHelper(TWriter* writer, const TTuple& t, std::integer_sequence<int, Is...>)
 {
     ((std::get<Is>(t).has_value() ? writer->template Set<start + Is>(std::get<Is>(t).value()) : void(0)), ...);
 }
 
 // Calls writer->Set() for each element which has a value in the tuple of optionals t
-template<int start, int end, class T, class Tuple>
-void optional_insert_state_ctf(T* writer, const Tuple& t)
+template<int start, int end, class TWriter, class TTuple>
+void InsertStateOptional(TWriter* writer, const TTuple& t)
 {
-    optional_insert_state_ctf_helper<start>(writer, t, std::make_integer_sequence<int, gcem::abs(start) + end>{});
+    InsertStateOptionalHelper<start>(writer, t, std::make_integer_sequence<int, gcem::abs(start) + end>{});
 }
 
 } // namespace detail
 
-template<class StateT>
-class StateReaderWriter : public StateReader<StateT>
+template<class TState>
+class StateReaderWriter : public StateReader<TState>
 {
 public:
 
     // Inherit constructors
-    using StateReader<StateT>::StateReader;
+    using StateReader<TState>::StateReader;
 
     // Bring in dependencies from parent:
-    using R = StateReader<StateT>;
-    using typename R::data_t;
+    using R = StateReader<TState>;
+    using typename R::StateData;
     using typename R::StateEnumCommon;
     using typename R::StateEnum;
-    template<int I> using get_data_t = typename R::template get_data_t<I>;
+    template<int state_data_index> using get_data_t = typename R::template get_data_t<state_data_index>;
 
-    // Set the specified state data (I) at the current write position (the end of the vector) to val
-    template<int I, bool IgnoreDuplicates = false>
-    void Set(get_data_t<I>&& val)
+    // Set the specified state data (state_data_index) at the current write position (the end of the vector) to val
+    template<int state_data_index, bool ignore_duplicates = false>
+    void Set(get_data_t<state_data_index>&& val)
     {
         assert(R::state_);
-        auto& vec = R::state_->template Get<I>();
+        auto& vec = R::state_->template Get<state_data_index>();
         auto& vecElem = vec.back(); // Current vec element (always the end when writing)
 
-        // There can only be one state data value for a given pos_t, so we won't always be adding a new element to the vector
+        // There can only be one state data value for a given OrderRowPosition, so we won't always be adding a new element to the vector
         if (vecElem.first != R::cur_pos_)
         {
-            if constexpr (!IgnoreDuplicates)
+            if constexpr (!ignore_duplicates)
             {
                 // If the latest value in the state is the same
                 // as what we're trying to add to the state, don't add it
@@ -511,83 +515,83 @@ public:
             vec.push_back({R::cur_pos_, std::move(val)});
 
             // Adjust current index
-            size_t& index = R::cur_indexes_[I + R::enum_common_count_]; // Current index within state data for data type I
+            size_t& index = R::cur_indexes_[state_data_index + R::enum_common_count_]; // Current index within state data for data type I
             ++index;
         }
         else
             vecElem.second = std::move(val); // Update current element
     }
 
-    // Set the specified state data (I) at the current write position (the end of the vector) to val
-    template<int I, bool IgnoreDuplicates = false>
-    inline void Set(const get_data_t<I>& val)
+    // Set the specified state data (state_data_index) at the current write position (the end of the vector) to val
+    template<int state_data_index, bool ignore_duplicates = false>
+    inline void Set(const get_data_t<state_data_index>& val)
     {
-        get_data_t<I> valCopy = val;
-        Set<I, IgnoreDuplicates>(std::move(valCopy));
+        get_data_t<state_data_index> valCopy = val;
+        Set<state_data_index, ignore_duplicates>(std::move(valCopy));
     }
 
     // For non-persistent state values. Next time SetWritePos is called, nextVal will automatically be set.
-    template<int I, bool IgnoreDuplicates = false>
-    inline void SetSingle(get_data_t<I>&& val, get_data_t<I>&& nextVal)
+    template<int state_data_index, bool ignore_duplicates = false>
+    inline void SetSingle(get_data_t<state_data_index>&& val, get_data_t<state_data_index>&& nextVal)
     {
-        std::get<I + R::enum_common_count_>(next_vals_) = std::move(nextVal);
+        std::get<state_data_index + R::enum_common_count_>(next_vals_) = std::move(nextVal);
         has_next_vals_ = true;
-        Set<I, IgnoreDuplicates>(std::move(val));
+        Set<state_data_index, ignore_duplicates>(std::move(val));
     }
 
     // For non-persistent state values. Next time SetWritePos is called, nextVal will automatically be set.
-    template<int I, bool IgnoreDuplicates = false>
-    inline void SetSingle(const get_data_t<I>& val, const get_data_t<I>& nextVal)
+    template<int state_data_index, bool ignore_duplicates = false>
+    inline void SetSingle(const get_data_t<state_data_index>& val, const get_data_t<state_data_index>& nextVal)
     {
-        std::get<I + R::enum_common_count_>(next_vals_) = nextVal;
+        std::get<state_data_index + R::enum_common_count_>(next_vals_) = nextVal;
         has_next_vals_ = true;
-        Set<I, IgnoreDuplicates>(val);
+        Set<state_data_index, ignore_duplicates>(val);
     }
 
     // Sets the initial state
-    void SetInitialState(data_t&& vals)
+    void SetInitialState(StateData&& vals)
     {
         assert(R::state_);
         R::state_->GetInitialState() = std::move(vals);
     }
 
     // Sets the initial state
-    inline void SetInitialState(const data_t& vals)
+    inline void SetInitialState(const StateData& vals)
     {
-        data_t valsCopy = vals;
+        StateData valsCopy = vals;
         SetInitialState(std::move(valsCopy));
     }
 
     // Inserts state data at current position. Use with Copy() in order to "resume" a state.
-    void Insert(const data_t& vals)
+    void Insert(const StateData& vals)
     {
         // Calls Set() for each element in vals
-        detail::insert_state_ctf<R::enum_lower_bound_, R::enum_upper_bound_>(this, vals);
+        detail::InsertState<R::enum_lower_bound_, R::enum_upper_bound_>(this, vals);
     }
 
     // Call this at the start of an inner loop before Set() is called
-    void SetWritePos(pos_t pos)
+    void SetWritePos(OrderRowPosition pos)
     {
         R::cur_pos_ = pos;
 
         // If SetSingle() was used, the next values are set here
         if (has_next_vals_)
         {
-            detail::optional_insert_state_ctf<R::enum_lower_bound_, R::enum_upper_bound_>(this, next_vals_);
+            detail::InsertStateOptional<R::enum_lower_bound_, R::enum_upper_bound_>(this, next_vals_);
             next_vals_ = {}; // Clear the tuple and reset optionals
             has_next_vals_ = false;
         }
     }
 
     // Call this at the start of an inner loop before Set() is called
-    inline void SetWritePos(order_index_t order, row_index_t row)
+    inline void SetWritePos(OrderIndex order, RowIndex row)
     {
-        SetWritePos(GetPos(order, row));
+        SetWritePos(GetOrderRowPosition(order, row));
     }
 
 private:
 
-    detail::optional_state_data_t<data_t> next_vals_;
+    detail::optional_state_data_t<StateData> next_vals_;
     bool has_next_vals_{false};
 };
 
@@ -605,14 +609,14 @@ struct StateReaders
     GlobalStateReader<ModuleClass> global_reader;
     std::vector<ChannelStateReader<ModuleClass>> channel_readers;
 
-    void SetReadPos(pos_t newPos)
+    void SetReadPos(OrderRowPosition newPos)
     {
         global_reader.SetReadPos();
         for (auto& temp : channel_readers)
             temp.SetReadPos();
     }
 
-    void SetReadPos(order_index_t order, row_index_t row) { SetReadPos(GetPos(order, row)); }
+    void SetReadPos(OrderIndex order, RowIndex row) { SetReadPos(GetOrderRowPosition(order, row)); }
 
     void Reset()
     {
@@ -628,23 +632,23 @@ struct StateReaderWriters
     GlobalStateReaderWriter<ModuleClass> global_reader_writer;
     std::vector<ChannelStateReaderWriter<ModuleClass>> channel_reader_writers;
 
-    void SetReadPos(pos_t newPos)
+    void SetReadPos(OrderRowPosition newPos)
     {
         global_reader_writer.SetReadPos();
         for (auto& temp : channel_reader_writers)
             temp.SetReadPos();
     }
 
-    void SetReadPos(order_index_t order, row_index_t row) { SetReadPos(GetPos(order, row)); }
+    void SetReadPos(OrderIndex order, RowIndex row) { SetReadPos(GetOrderRowPosition(order, row)); }
 
-    void SetWritePos(pos_t pos)
+    void SetWritePos(OrderRowPosition pos)
     {
         global_reader_writer.SetWritePos(pos);
         for (auto& temp : channel_reader_writers)
             temp.SetWritePos(pos);
     }
 
-    void SetWritePos(order_index_t order, row_index_t row) { SetWritePos(GetPos(order, row)); }
+    void SetWritePos(OrderIndex order, RowIndex row) { SetWritePos(GetOrderRowPosition(order, row)); }
 
     void Reset()
     {
@@ -652,6 +656,26 @@ struct StateReaderWriters
         for (auto& temp : channel_reader_writers)
             temp.Reset();
     }
+
+    void Save()
+    {
+        saved_channel_states_.resize(channel_reader_writers.size());
+        saved_global_data_ = global_reader_writer.Copy();
+        for (unsigned i = 0; i < channel_reader_writers.size(); ++i)
+            saved_channel_states_[i] = channel_reader_writers[i].Copy();
+    }
+
+    void Restore()
+    {
+        assert(saved_channel_states_.size() == channel_reader_writers.size());
+        global_reader_writer.Insert(saved_global_data_);
+        for (unsigned i = 0; i < channel_reader_writers.size(); ++i)
+            channel_reader_writers[i].Insert(saved_channel_states_[i]);
+    }
+
+private:
+    GlobalState<ModuleClass>::StateData saved_global_data_;
+    std::vector<ChannelState<ModuleClass>::StateData> saved_channel_states_;
 };
 
 

--- a/include/core/state.h
+++ b/include/core/state.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include "config_types.h"
+#include "data.h"
 #include "note.h"
 #include "effects.h"
 
@@ -83,8 +84,8 @@ using LoopbackStateData = OrderRowPosition; // Order/Row where the PosJump occur
 using TempoStateData = EffectValueXX;
 using SpeedAStateData = EffectValueXX;
 using SpeedBStateData = EffectValueXX;
-using PatBreakStateData = EffectValueXX;
-using PosJumpStateData = EffectValueXX;
+using PatBreakStateData = RowIndex;
+using PosJumpStateData = OrderIndex;
 
 // Per-channel state data types
 

--- a/include/core/status.h
+++ b/include/core/status.h
@@ -18,6 +18,7 @@
 #include <exception>
 #include <stdexcept>
 #include <type_traits>
+#include <optional>
 
 namespace d2m {
 
@@ -136,7 +137,7 @@ public:
         m_Category = Category::None;
     }
 
-    bool ErrorOccurred() const { return m_Error.first; }
+    bool ErrorOccurred() const { return m_Error.has_value(); }
     bool WarningsIssued() const { return !m_WarningMessages.empty(); }
     
     void PrintError(bool useStdErr = true) const;
@@ -148,13 +149,12 @@ public:
     void Clear()
     {
         m_WarningMessages.clear();
-        m_Error.first = false;
+        m_Error.reset();
     }
 
     void AddError(ModuleException&& error)
     {
-        m_Error.second = std::move(error);
-        m_Error.first = true;
+        m_Error = std::move(error);
     }
 
     void AddWarning(const std::string& warningMessage)
@@ -170,10 +170,7 @@ public:
 
 private:
 
-    template <typename T>
-    using poor_mans_optional = std::pair<bool, T>;
-    
-    poor_mans_optional<ModuleException> m_Error;
+    std::optional<ModuleException> m_Error;
     std::vector<std::string> m_WarningMessages;
     Category m_Category;
 };

--- a/include/modules/dmf.h
+++ b/include/modules/dmf.h
@@ -32,7 +32,7 @@ namespace dmf {
         int16_t value;
     };
 
-    size_t GenerateDataImpl(DMF const* dmf, ModuleGeneratedDataMethods<DMF>* data);
+    size_t GenerateDataImpl(DMF const* dmf, ModuleGeneratedDataMethods<DMF>* genData);
 }
 
 template<>
@@ -54,45 +54,6 @@ template<>
 struct PatternMetadata<DMF>
 {
     std::string name;
-};
-
-template<>
-class GlobalState<DMF>
-{
-public:
-    enum GlobalStateEnum
-    {
-        kTempo,
-        kCount // Required
-    };
-
-    using tempo_t = std::vector<std::pair<global_pos_t, TempoNode>>;
-
-    // A data_t tuple is required for every GlobalState/ChannelState specialization
-    // element indexes coorespond to GlobalStateEnum variants
-    using data_t = std::tuple<tempo_t>;
-
-    // Returns a mutable reference to state data at index I
-    template<size_t I>
-    detail::state_vec_t<I, GlobalState<DMF>>& GetMut()
-    {
-        if constexpr (I == kTempo)
-            return tempo_;
-        throw std::out_of_range{""};
-    }
-
-    // Returns an immutable reference to state data at index I
-    template<size_t I>
-    const detail::state_vec_t<I, GlobalState<DMF>>& Get() const
-    {
-        if constexpr (I == kTempo)
-            return tempo_;
-        throw std::out_of_range{""};
-    }
-
-private:
-
-    tempo_t tempo_;
 };
 
 template<> template<size_t DataFlagsT>

--- a/include/modules/dmf.h
+++ b/include/modules/dmf.h
@@ -72,6 +72,7 @@ namespace dmf {
 inline constexpr int kDMFNoInstrument = -1;
 inline constexpr int kDMFNoVolume = -1;
 inline constexpr int kDMFVolumeMax = 15; /* ??? */
+inline constexpr int kDMFGameBoyVolumeMax = 15;
 inline constexpr int kDMFNoEffectVal = -1;
 
 // Effect codes used by the DMF format:

--- a/include/modules/dmf.h
+++ b/include/modules/dmf.h
@@ -161,8 +161,7 @@ struct System
 
     System() = default;
     System(Type type, uint8_t id, std::string name, uint8_t channels)
-        : type(type), id(id), name(name), channels(channels)
-    {}
+        : type(type), id(id), name(name), channels(channels) {}
 };
 
 struct VisualInfo
@@ -174,8 +173,8 @@ struct VisualInfo
 struct ModuleInfo
 {
     uint8_t timeBase, tickTime1, tickTime2, framesMode, usingCustomHZ, customHZValue1, customHZValue2, customHZValue3;
-    uint32_t totalRowsPerPattern;
-    uint8_t totalRowsInPatternMatrix;
+    uint32_t totalRowsPerPattern; // TODO: Should remove this eventually (duplicate w/ ModuleData)
+    uint8_t totalRowsInPatternMatrix; // (orders) TODO: Should remove this eventually (duplicate w/ ModuleData)
 };
 
 struct FMOps
@@ -336,8 +335,6 @@ public:
     // Factory requires destructor to be public
     ~DMF();
 
-    ////////////
-
     // Returns the initial BPM of the module
     void GetBPM(unsigned& numerator, unsigned& denominator) const;
     double GetBPM() const;
@@ -345,6 +342,7 @@ public:
     /*
      * In spite of what the Deflemask manual says, portamento effects are automatically turned off if they
      * stay on long enough without a new note being played. These methods help handle those edge cases.
+     * TODO: Remove these methods once Generated Data stuff is finished
      */
     int GetRowsUntilPortUpAutoOff(const NoteSlot& note, int portUpParam) const;
     static int GetRowsUntilPortUpAutoOff(unsigned ticksPerRowPair, const NoteSlot& note, int portUpParam);
@@ -357,14 +355,13 @@ public:
     }
 
     const dmf::System& GetSystem() const { return m_System; }
-    const dmf::VisualInfo& GetVisualInfo() const { return m_VisualInfo; }
-    const dmf::ModuleInfo& GetModuleInfo() const { return m_ModuleInfo; }
 
     uint8_t GetTotalWavetables() const { return m_TotalWavetables; }
-
     uint32_t** GetWavetableValues() const { return m_WavetableValues; }
     uint32_t GetWavetableValue(unsigned wavetable, unsigned index) const { return m_WavetableValues[wavetable][index]; }
+
 private:
+
     void ImportRaw(const std::string& filename) override;
     void ExportRaw(const std::string& filename) override;
     void ConvertRaw(const ModulePtr& input) override;

--- a/include/modules/dmf.h
+++ b/include/modules/dmf.h
@@ -335,21 +335,6 @@ public:
     void GetBPM(unsigned& numerator, unsigned& denominator) const;
     double GetBPM() const;
 
-    /*
-     * In spite of what the Deflemask manual says, portamento effects are automatically turned off if they
-     * stay on long enough without a new note being played. These methods help handle those edge cases.
-     * TODO: Remove these methods once Generated Data stuff is finished
-     */
-    int GetRowsUntilPortUpAutoOff(const NoteSlot& note, int portUpParam) const;
-    static int GetRowsUntilPortUpAutoOff(unsigned ticksPerRowPair, const NoteSlot& note, int portUpParam);
-    int GetRowsUntilPortDownAutoOff(const NoteSlot& note, int portDownParam) const;
-    static int GetRowsUntilPortDownAutoOff(unsigned ticksPerRowPair, const NoteSlot& note, int portDownParam);
-
-    inline unsigned GetTicksPerRowPair() const
-    {
-        return m_ModuleInfo.timeBase * (m_ModuleInfo.tickTime1 + m_ModuleInfo.tickTime2);
-    }
-
     const dmf::System& GetSystem() const { return m_System; }
 
     uint8_t GetTotalWavetables() const { return m_TotalWavetables; }
@@ -361,7 +346,7 @@ private:
     void ImportImpl(const std::string& filename) override;
     void ExportImpl(const std::string& filename) override;
     void ConvertImpl(const ModulePtr& input) override;
-    size_t GenerateDataImpl(size_t dataFlags) const override;
+    size_t GenerateDataImpl(size_t data_flags) const override;
 
     using Reader = StreamReader<zstr::ifstream, Endianness::Little>;
 

--- a/include/modules/dmf.h
+++ b/include/modules/dmf.h
@@ -25,20 +25,12 @@ class DMF;
 template<>
 struct ModuleGlobalData<DMF> : public ModuleGlobalDataDefault<DataStorageType::COR> {};
 
-namespace dmf {
-    struct Effect
-    {
-        int16_t code;
-        int16_t value;
-    };
-}
-
 template<>
 struct Row<DMF>
 {
     NoteSlot note;
     int16_t volume;
-    dmf::Effect effect[4]; // Deflemask allows four effects columns per channel regardless of the system
+    Effect effect[4]; // Deflemask allows four effects columns per channel regardless of the system
     int16_t instrument;
 };
 
@@ -60,38 +52,77 @@ struct PatternMetadata<DMF>
 
 namespace dmf {
 
-static const int DMFNoInstrument = -1;
-static const int DMFNoVolume = -1;
-static const int DMFVolumeMax = 15; /* ??? */
+inline constexpr int kDMFNoInstrument = -1;
+inline constexpr int kDMFNoVolume = -1;
+inline constexpr int kDMFVolumeMax = 15; /* ??? */
+inline constexpr int kDMFNoEffectVal = -1;
 
-// Deflemask effects shared by all systems:
+// Effect codes used by the DMF format:
 namespace EffectCode
 {
     enum
     {
-        NoEffect=-1, NoEffectVal=-1,
-        Arp=0x0, PortUp=0x1, PortDown=0x2, Port2Note=0x3, Vibrato=0x4, Port2NoteVolSlide=0x5, VibratoVolSlide=0x6,
-        Tremolo=0x7, Panning=0x8, SetSpeedVal1=0x9, VolSlide=0xA, PosJump=0xB, Retrig=0xC, PatBreak=0xD,
-        ArpTickSpeed=0xE0, NoteSlideUp=0xE1, NoteSlideDown=0xE2, SetVibratoMode=0xE3, SetFineVibratoDepth=0xE4,
-        SetFinetune=0xE5, SetSamplesBank=0xEB, NoteCut=0xEC, NoteDelay=0xED, SyncSignal=0xEE, SetGlobalFinetune=0xEF,
-        SetSpeedVal2=0xF
+        kNoEffect=-1,
+        kArp                    =0x0,
+        kPortUp                 =0x1,
+        kPortDown               =0x2,
+        kPort2Note              =0x3,
+        kVibrato                =0x4,
+        kPort2NoteVolSlide      =0x5,
+        kVibratoVolSlide        =0x6,
+        kTremolo                =0x7,
+        kPanning                =0x8,
+        kSetSpeedVal1           =0x9,
+        kVolSlide               =0xA,
+        kPosJump                =0xB,
+        kRetrig                 =0xC,
+        kPatBreak               =0xD,
+        kArpTickSpeed           =0xE0,
+        kNoteSlideUp            =0xE1,
+        kNoteSlideDown          =0xE2,
+        kSetVibratoMode         =0xE3,
+        kSetFineVibratoDepth    =0xE4,
+        kSetFinetune            =0xE5,
+        kSetSamplesBank         =0xEB,
+        kNoteCut                =0xEC,
+        kNoteDelay              =0xED,
+        kSyncSignal             =0xEE,
+        kSetGlobalFinetune      =0xEF,
+        kSetSpeedVal2           =0xF,
+
+        // Game Boy exclusive
+        kGameBoySetWave                 =0x10,
+        kGameBoySetNoisePolyCounterMode =0x11,
+        kGameBoySetDutyCycle            =0x12,
+        kGameBoySetSweepTimeShift       =0x13,
+        kGameBoySetSweepDir             =0x14
+
+        // TODO: Add enums for effects exclusive to the rest of Deflemask's systems.
     };
 }
 
-// Deflemask effects exclusive to the Game Boy system:
-namespace GameBoyEffectCode
+// Custom dmf2mod internal effect codes (see effects.h)
+namespace Effects
 {
     enum
     {
-        SetWave=0x10,
-        SetNoisePolyCounterMode=0x11,
-        SetDutyCycle=0x12,
-        SetSweepTimeShift=0x13,
-        SetSweepDir=0x14
+        kArpTickSpeed=1,
+        kNoteSlideUp,
+        kNoteSlideDown,
+        kSetVibratoMode,
+        kSetFineVibratoDepth,
+        kSetFinetune,
+        kSetSamplesBank,
+        kSyncSignal,
+        kSetGlobalFinetune,
+        kGameBoySetWave,
+        kGameBoySetNoisePolyCounterMode,
+        kGameBoySetDutyCycle,
+        kGameBoySetSweepTimeShift,
+        kGameBoySetSweepDir
     };
 }
 
-// To do: Add enums for effects exclusive to the rest of Deflemask's systems.
 
 struct System
 {

--- a/include/modules/dmf.h
+++ b/include/modules/dmf.h
@@ -46,6 +46,22 @@ struct PatternMetadata<DMF>
     std::string name;
 };
 
+template<>
+struct SoundIndex<DMF>
+{
+    enum Types { kSquare, kWave, /*Other options here*/ };
+
+    struct Square { uint8_t id; operator uint8_t() const { return id; } };
+    struct Wave { uint8_t id; operator uint8_t() const { return id; } };
+    struct Noise { uint8_t id; operator uint8_t() const { return id; } }; // Placeholder
+
+    using type = std::variant<Square, Wave, Noise>;
+};
+
+inline constexpr bool operator==(const SoundIndex<DMF>::Square& lhs, const SoundIndex<DMF>::Square& rhs) { return lhs.id == rhs.id; }
+inline constexpr bool operator==(const SoundIndex<DMF>::Wave& lhs, const SoundIndex<DMF>::Wave& rhs) { return lhs.id == rhs.id; }
+inline constexpr bool operator==(const SoundIndex<DMF>::Noise& lhs, const SoundIndex<DMF>::Noise& rhs) { return lhs.id == rhs.id; }
+
 ///////////////////////////////////////////////////////////
 // dmf namespace
 ///////////////////////////////////////////////////////////

--- a/include/modules/dmf.h
+++ b/include/modules/dmf.h
@@ -31,8 +31,6 @@ namespace dmf {
         int16_t code;
         int16_t value;
     };
-
-    size_t GenerateDataImpl(DMF const* dmf, ModuleGeneratedDataMethods<DMF>* genData);
 }
 
 template<>
@@ -55,17 +53,6 @@ struct PatternMetadata<DMF>
 {
     std::string name;
 };
-
-template<> template<size_t DataFlagsT>
-size_t ModuleGeneratedDataMethods<DMF>::Generate()
-{
-    /*
-     * Currently there's only one method implemented which calculates all generated data.
-     * The DataFlagsT parameter is ignored, but with some if-constexpr's, it could be used to
-     * call methods that generate only the data which is requested.
-     */
-    return dmf::GenerateDataImpl(module_class_, this);
-}
 
 ///////////////////////////////////////////////////////////
 // dmf namespace
@@ -323,9 +310,10 @@ public:
 
 private:
 
-    void ImportRaw(const std::string& filename) override;
-    void ExportRaw(const std::string& filename) override;
-    void ConvertRaw(const ModulePtr& input) override;
+    void ImportImpl(const std::string& filename) override;
+    void ExportImpl(const std::string& filename) override;
+    void ConvertImpl(const ModulePtr& input) override;
+    size_t GenerateDataImpl(size_t dataFlags) const override;
 
     using Reader = StreamReader<zstr::ifstream, Endianness::Little>;
 

--- a/include/modules/dmf.h
+++ b/include/modules/dmf.h
@@ -31,6 +31,8 @@ namespace dmf {
         int16_t code;
         int16_t value;
     };
+
+    size_t GenerateDataImpl(DMF const* dmf, ModuleGeneratedDataMethods<DMF>* data);
 }
 
 template<>
@@ -93,6 +95,16 @@ private:
     tempo_t tempo_;
 };
 
+template<> template<size_t DataFlagsT>
+size_t ModuleGeneratedDataMethods<DMF>::Generate()
+{
+    /*
+     * Currently there's only one method implemented which calculates all generated data.
+     * The DataFlagsT parameter is ignored, but with some if-constexpr's, it could be used to
+     * call methods that generate only the data which is requested.
+     */
+    return dmf::GenerateDataImpl(module_class_, this);
+}
 
 ///////////////////////////////////////////////////////////
 // dmf namespace

--- a/include/modules/dmf.h
+++ b/include/modules/dmf.h
@@ -49,13 +49,14 @@ struct PatternMetadata<DMF>
 template<>
 struct SoundIndex<DMF>
 {
-    enum Types { kSquare, kWave, /*Other options here*/ };
+    enum Types { kNone, kSquare, kWave, kNoise /*Other options here*/ };
 
+    using None = std::monostate;
     struct Square { uint8_t id; operator uint8_t() const { return id; } };
     struct Wave { uint8_t id; operator uint8_t() const { return id; } };
     struct Noise { uint8_t id; operator uint8_t() const { return id; } }; // Placeholder
 
-    using type = std::variant<Square, Wave, Noise>;
+    using type = std::variant<None, Square, Wave, Noise>;
 };
 
 inline constexpr bool operator==(const SoundIndex<DMF>::Square& lhs, const SoundIndex<DMF>::Square& rhs) { return lhs.id == rhs.id; }

--- a/include/modules/dmf.h
+++ b/include/modules/dmf.h
@@ -23,7 +23,7 @@ namespace d2m {
 class DMF;
 
 template<>
-struct ModuleGlobalData<DMF> : public ModuleGlobalDataGeneric<DataStorageType::COR> {};
+struct ModuleGlobalData<DMF> : public ModuleGlobalDataDefault<DataStorageType::COR> {};
 
 namespace dmf {
     struct Effect
@@ -53,6 +53,46 @@ struct PatternMetadata<DMF>
 {
     std::string name;
 };
+
+template<>
+class GlobalState<DMF>
+{
+public:
+    enum GlobalStateEnum
+    {
+        kTempo,
+        kCount // Required
+    };
+
+    using tempo_t = std::vector<std::pair<global_pos_t, TempoNode>>;
+
+    // A data_t tuple is required for every GlobalState/ChannelState specialization
+    // element indexes coorespond to GlobalStateEnum variants
+    using data_t = std::tuple<tempo_t>;
+
+    // Returns a mutable reference to state data at index I
+    template<size_t I>
+    detail::state_vec_t<I, GlobalState<DMF>>& GetMut()
+    {
+        if constexpr (I == kTempo)
+            return tempo_;
+        throw std::out_of_range{""};
+    }
+
+    // Returns an immutable reference to state data at index I
+    template<size_t I>
+    const detail::state_vec_t<I, GlobalState<DMF>>& Get() const
+    {
+        if constexpr (I == kTempo)
+            return tempo_;
+        throw std::out_of_range{""};
+    }
+
+private:
+
+    tempo_t tempo_;
+};
+
 
 ///////////////////////////////////////////////////////////
 // dmf namespace

--- a/include/modules/mod.h
+++ b/include/modules/mod.h
@@ -214,24 +214,17 @@ using PriorityEffect = std::pair<mod::EffectPriority, d2m::Effect>;
 class MODException : public ModuleException
 {
 public:
-    template <class T, class = std::enable_if_t<std::is_enum_v<T> && std::is_convertible_v<std::underlying_type_t<T>, int>>>
-    MODException(Category category, T errorCode, const std::string& args = "")
-        : ModuleException(category, static_cast<int>(errorCode), CreateErrorMessage(category, (int)errorCode, args)) {}
+    template<class T>
+    MODException(Category category, T error_code, const std::string& args = "")
+        : ModuleException(category, static_cast<int>(error_code), CreateErrorMessage(category, static_cast<int>(error_code), args)) {}
 
 private:
     // Creates module-specific error message from an error code and string argument
-    std::string CreateErrorMessage(Category category, int errorCode, const std::string& arg);
+    std::string CreateErrorMessage(Category category, int error_code, const std::string& arg);
 };
 
 class MODConversionOptions : public ConversionOptionsInterface<MODConversionOptions>
 {
-private:
-
-    // Only allow the Factory to construct this class
-    friend class Builder<MODConversionOptions, ConversionOptionsBase>;
-
-    MODConversionOptions() = default;
-
 public:
 
     // Factory requires destructor to be public
@@ -263,18 +256,14 @@ public:
 
 private:
 
+    // Only allow the Factory to construct this class
+    friend class Builder<MODConversionOptions, ConversionOptionsBase>;
+
+    MODConversionOptions() = default;
 };
 
 class MOD : public ModuleInterface<MOD>
 {
-private:
-
-    // Only allow the Factory to construct this class
-    friend class Builder<MOD, ModuleBase>;
-
-    MOD();
-    void CleanUp() {};
-
 public:
 
     // Factory requires destructor to be public
@@ -312,22 +301,28 @@ public:
     static constexpr unsigned kVolumeMax = 64u; // Yes, there are 65 different values for the volume
 
 private:
+
+    // Only allow the Factory to construct this class
+    friend class Builder<MOD, ModuleBase>;
+
+    MOD();
+    void CleanUp() {};
+
     using SampleMap = std::map<SoundIndexType<DMF>, mod::DMFSampleMapper>;
 
     // Module requirements:
     void ImportImpl(const std::string& filename) override;
     void ExportImpl(const std::string& filename) override;
     void ConvertImpl(const ModulePtr& input) override;
-    size_t GenerateDataImpl(size_t dataFlags) const override { return 0; }
+    size_t GenerateDataImpl(size_t data_flags) const override { return 1; }
 
     // Conversion from DMF:
     void ConvertFromDMF(const DMF& dmf);
     void DMFConvertSamples(const DMF& dmf, SampleMap& sample_map);
     void DMFConvertSampleData(const DMF& dmf, const SampleMap& sample_map);
-
     void DMFConvertPatterns(const DMF& dmf, const SampleMap& sample_map);
     mod::PriorityEffect DMFConvertEffects(ChannelStateReader<DMF>& state);
-    Row<MOD> DMFConvertNote(ChannelStateReader<DMF>& state, mod::DMFSampleMapper::NoteRange& note_range, bool& note_playing, const SampleMap& sample_map, mod::PriorityEffect& mod_effect);
+    Row<MOD> DMFConvertNote(ChannelStateReader<DMF>& state, mod::DMFSampleMapper::NoteRange& note_range, bool& note_playing, bool on_jump_destination, const SampleMap& sample_map, mod::PriorityEffect& mod_effect);
     void ApplyEffects(std::array<Row<MOD>, 4>& row_data, const std::array<mod::PriorityEffect, 4>& mod_effect, std::vector<mod::PriorityEffect>& global_effects);
 
     void DMFConvertInitialBPM(const DMF& dmf, unsigned& tempo, unsigned& speed);
@@ -339,7 +334,6 @@ private:
     void ExportPatterns(std::ofstream& fout) const;
     void ExportSampleData(std::ofstream& fout) const;
 
-private:
     //////////// Temporaries used during DMF-->MOD conversion
     const bool m_UsingSetupPattern = true; // Whether to use a pattern at the start of the module to set up the initial tempo and other stuff.
 

--- a/include/modules/mod.h
+++ b/include/modules/mod.h
@@ -326,8 +326,8 @@ private:
 
     // Conversion from DMF:
     void ConvertFromDMF(const DMF& dmf);
-    void DMFConvertSamples(const DMF& dmf, SampleMap& sampleMap);
-    void DMFConvertSampleData(const DMF& dmf, const SampleMap& sampleMap);
+    void DMFConvertSamples(const DMF& dmf, SampleMap& sample_map);
+    void DMFConvertSampleData(const DMF& dmf, const SampleMap& sample_map);
 
     void DMFConvertPatterns(const DMF& dmf, const SampleMap& sample_map);
     mod::PriorityEffect DMFConvertEffects(ChannelStateReader<DMF>& state);

--- a/include/modules/mod.h
+++ b/include/modules/mod.h
@@ -233,7 +233,7 @@ struct State
             channel[i].dutyCycle = 0; // Default is 0 or a 12.5% duty cycle square wave.
             channel[i].wavetable = 0; // Default is wavetable #0.
             channel[i].sampleChanged = true; // Whether dutyCycle or wavetable recently changed
-            channel[i].volume = dmf::DMFVolumeMax; // The max volume for a channel (in DMF units)
+            channel[i].volume = dmf::kDMFVolumeMax; // The max volume for a channel (in DMF units)
             channel[i].notePlaying = false; // Whether a note is currently playing on a channel
             channel[i].noteRange = DMFSampleMapper::NoteRange::First; // Which MOD sample note range is currently being used
             channel[i].persistentEffects = {};

--- a/include/modules/mod.h
+++ b/include/modules/mod.h
@@ -63,7 +63,7 @@ namespace EffectCode
         FineVolSlideDown=0xEB, CutSample=0xEC, DelaySample=0xED, DelayPattern=0xEE, InvertLoop=0xEF, SetSpeed=0xF0,
 
         /* The following are not actual MOD effects, but they are useful during conversions */
-        DutyCycleChange=0xFF0, WavetableChange=0xFF1 
+        DutyCycleChange=0xFE, WavetableChange=0xFF
     };
 }
 
@@ -196,9 +196,9 @@ struct State
         int jumpDestination; // DMF pattern matrix row where you are jumping to. Not a loop.
         Effect channelIndependentEffect;
         unsigned ticksPerRowPair; // DMF's time_base * (speed_a + speed_b)
-        channel_index_t channel;    // The current channel in DMF or MOD
-        order_index_t order;      // The current pattern matrix row in DMF
-        pattern_index_t patternRow; // The current pattern row in DMF?
+        ChannelIndex channel;    // The current channel in DMF or MOD
+        OrderIndex order;      // The current pattern matrix row in DMF
+        PatternIndex patternRow; // The current pattern row in DMF?
     } global;
 
     ChannelStateOld channel[4];

--- a/include/modules/mod.h
+++ b/include/modules/mod.h
@@ -34,10 +34,6 @@ struct ModuleGlobalData<MOD> : public ModuleGlobalDataDefault<DataStorageType::O
 template<>
 struct Row<MOD>
 {
-    //uint8_t SampleNumber;
-    //uint16_t SamplePeriod;
-    //unsigned EffectCode;
-    //unsigned EffectValue;
     SoundIndexType<MOD> sample;
     NoteSlot note;
     Effect effect;

--- a/include/modules/mod.h
+++ b/include/modules/mod.h
@@ -13,6 +13,7 @@
 #include <string>
 #include <sstream>
 #include <map>
+#include <array>
 
 namespace d2m {
 
@@ -180,8 +181,8 @@ public:
 
 private:
     SoundIndexType<DMF> dmf_sound_index_;
-    SoundIndexType<MOD> mod_sound_indexes_[3]; // Up to 3 MOD samples from one DMF sample
-    unsigned mod_sample_lengths_[3];
+    std::array<SoundIndexType<MOD>, 3> mod_sound_indexes_; // Up to 3 MOD samples from one DMF sample
+    std::array<unsigned, 3> mod_sample_lengths_;
     std::vector<Note> range_start_;
     int num_mod_samples_;
     SampleType sample_type_;

--- a/include/modules/mod.h
+++ b/include/modules/mod.h
@@ -295,7 +295,8 @@ public:
         TempoAccuracy,
         EffectIgnored,
         WaveDownsample,
-        MultipleEffects
+        MultipleEffects,
+        LoopbackInaccuracy
     };
 
     static constexpr unsigned kVolumeMax = 64u; // Yes, there are 65 different values for the volume
@@ -322,7 +323,7 @@ private:
     void DMFConvertSampleData(const DMF& dmf, const SampleMap& sample_map);
     void DMFConvertPatterns(const DMF& dmf, const SampleMap& sample_map);
     mod::PriorityEffect DMFConvertEffects(ChannelStateReader<DMF>& state);
-    Row<MOD> DMFConvertNote(ChannelStateReader<DMF>& state, mod::DMFSampleMapper::NoteRange& note_range, bool& note_playing, bool on_jump_destination, const SampleMap& sample_map, mod::PriorityEffect& mod_effect);
+    Row<MOD> DMFConvertNote(ChannelStateReader<DMF>& state, mod::DMFSampleMapper::NoteRange& note_range, bool& set_sample, int& set_vol_if_not, const SampleMap& sample_map, mod::PriorityEffect& mod_effect);
     void ApplyEffects(std::array<Row<MOD>, 4>& row_data, const std::array<mod::PriorityEffect, 4>& mod_effect, std::vector<mod::PriorityEffect>& global_effects);
 
     void DMFConvertInitialBPM(const DMF& dmf, unsigned& tempo, unsigned& speed);

--- a/include/modules/mod.h
+++ b/include/modules/mod.h
@@ -380,9 +380,10 @@ private:
     using SampleMap = std::map<mod::dmf_sample_id_t, mod::DMFSampleMapper>;
     using DMFSampleNoteRangeMap = std::map<mod::dmf_sample_id_t, std::pair<Note, Note>>;
 
-    void ImportRaw(const std::string& filename) override;
-    void ExportRaw(const std::string& filename) override;
-    void ConvertRaw(const ModulePtr& input) override;
+    void ImportImpl(const std::string& filename) override;
+    void ExportImpl(const std::string& filename) override;
+    void ConvertImpl(const ModulePtr& input) override;
+    size_t GenerateDataImpl(size_t dataFlags) const override { return 0; }
 
     // Conversion from DMF:
     void ConvertFromDMF(const DMF& dmf);

--- a/include/modules/mod.h
+++ b/include/modules/mod.h
@@ -196,9 +196,9 @@ struct State
         int jumpDestination; // DMF pattern matrix row where you are jumping to. Not a loop.
         Effect channelIndependentEffect;
         unsigned ticksPerRowPair; // DMF's time_base * (speed_a + speed_b)
-        unsigned channel;    // The current channel in DMF or MOD
-        unsigned order;      // The current pattern matrix row in DMF
-        unsigned patternRow; // The current pattern row in DMF?
+        channel_index_t channel;    // The current channel in DMF or MOD
+        order_index_t order;      // The current pattern matrix row in DMF
+        pattern_index_t patternRow; // The current pattern row in DMF?
     } global;
 
     ChannelStateOld channel[4];

--- a/include/modules/mod.h
+++ b/include/modules/mod.h
@@ -23,7 +23,7 @@ namespace d2m {
 class MOD;
 
 template<>
-struct ModuleGlobalData<MOD> : public ModuleGlobalDataGeneric<DataStorageType::ORC>
+struct ModuleGlobalData<MOD> : public ModuleGlobalDataDefault<DataStorageType::ORC>
 {
     // In the future, we'll be able to detect when a MOD module
     // was created with dmf2mod, which will help when converting
@@ -167,7 +167,7 @@ using PriorityEffectsMap = std::multimap<mod::EffectPriority, mod::Effect>;
 
 // The current square wave duty cycle, note volume, and other information that the 
 //      tracker stores for each channel while playing a tracker file.
-struct ChannelState
+struct ChannelStateOld
 {
     enum PORTDIR
     {
@@ -201,8 +201,8 @@ struct State
         unsigned patternRow; // The current pattern row in DMF?
     } global;
 
-    ChannelState channel[4];
-    ChannelState channelCopy[4];
+    ChannelStateOld channel[4];
+    ChannelStateOld channelCopy[4];
 
     Row<MOD> channelRows[4];
 
@@ -238,7 +238,7 @@ struct State
             channel[i].noteRange = DMFSampleMapper::NoteRange::First; // Which MOD sample note range is currently being used
             channel[i].persistentEffects = {};
             channel[i].rowsUntilPortAutoOff = -1; // -1 = port not on; 0 = need to turn port off; >0 = rows until port auto off
-            channel[i].portDirection = ChannelState::PORT_UP;
+            channel[i].portDirection = ChannelStateOld::PORT_UP;
             channel[i].portParam = 0;
             channel[i].currentNote = {};
 

--- a/include/modules/mod.h
+++ b/include/modules/mod.h
@@ -34,10 +34,13 @@ struct ModuleGlobalData<MOD> : public ModuleGlobalDataDefault<DataStorageType::O
 template<>
 struct Row<MOD>
 {
-    uint8_t SampleNumber;
-    uint16_t SamplePeriod;
-    unsigned EffectCode;
-    unsigned EffectValue;
+    //uint8_t SampleNumber;
+    //uint16_t SamplePeriod;
+    //unsigned EffectCode;
+    //unsigned EffectValue;
+    SoundIndexType<MOD> sample;
+    NoteSlot note;
+    Effect effect;
 };
 
 ///////////////////////////////////////////////////////////
@@ -46,54 +49,97 @@ struct Row<MOD>
 
 namespace mod {
 
-// MOD effects:
+// Effect codes used by the MOD format:
 // An effect is represented with 12 bits, which is 3 groups of 4 bits: [a][x][y] or [a][b][x]
 // The effect code is [a] or [a][b], and the effect value is [x][y] or [x]. [x][y] codes are the
 // extended effects. All effect codes are stored below. Non-extended effects have 0x0 in the right-most
 // nibble in order to line up with the extended effects:
 namespace EffectCode
 {
-    enum EffectCode
+    enum
     {
-        NoEffect=0x00, NoEffectVal=0x00, NoEffectCode=0x00, /* NoEffect is the same as ((uint16_t)NoEffectCode << 4) | NoEffectVal */
-        Arp=0x00, PortUp=0x10, PortDown=0x20, Port2Note=0x30, Vibrato=0x40, Port2NoteVolSlide=0x50, VibratoVolSlide=0x60,
-        Tremolo=0x70, Panning=0x80, SetSampleOffset=0x90, VolSlide=0xA0, PosJump=0xB0, SetVolume=0xC0, PatBreak=0xD0,
-        SetFilter=0xE0, FineSlideUp=0xE1, FineSlideDown=0xE2, SetGlissando=0xE3, SetVibratoWaveform=0xE4,
-        SetFinetune=0xE5, LoopPattern=0xE6, SetTremoloWaveform=0xE7, RetriggerSample=0xE9, FineVolSlideUp=0xEA,
-        FineVolSlideDown=0xEB, CutSample=0xEC, DelaySample=0xED, DelayPattern=0xEE, InvertLoop=0xEF, SetSpeed=0xF0,
-
-        /* The following are not actual MOD effects, but they are useful during conversions */
-        DutyCycleChange=0xFE, WavetableChange=0xFF
+        kNoEffect           =0x00,
+        kNoEffectVal        =0x00,
+        kNoEffectCode       =0x00, /* NoEffect is the same as ((uint16_t)NoEffectCode << 4) | NoEffectVal */
+        kArp                =0x00,
+        kPortUp             =0x10,
+        kPortDown           =0x20,
+        kPort2Note          =0x30,
+        kVibrato            =0x40,
+        kPort2NoteVolSlide  =0x50,
+        kVibratoVolSlide    =0x60,
+        kTremolo            =0x70,
+        kPanning            =0x80,
+        kSetSampleOffset    =0x90,
+        kVolSlide           =0xA0,
+        kPosJump            =0xB0,
+        kSetVolume          =0xC0,
+        kPatBreak           =0xD0,
+        kSetFilter          =0xE0,
+        kFineSlideUp        =0xE1,
+        kFineSlideDown      =0xE2,
+        kSetGlissando       =0xE3,
+        kSetVibratoWaveform =0xE4,
+        kSetFinetune        =0xE5,
+        kLoopPattern        =0xE6,
+        kSetTremoloWaveform =0xE7,
+        kRetriggerSample    =0xE9,
+        kFineVolSlideUp     =0xEA,
+        kFineVolSlideDown   =0xEB,
+        kCutSample          =0xEC,
+        kDelaySample        =0xED,
+        kDelayPattern       =0xEE,
+        kInvertLoop         =0xEF,
+        kSetSpeed           =0xF0
     };
 }
 
-struct Effect
+// Custom dmf2mod internal effect codes (see effects.h)
+namespace Effects
 {
-    uint16_t effect;
-    uint16_t value;
-};
+    enum
+    {
+        kSetSampleOffset=1,
+        kSetVolume,
+        kSetFilter,
+        kFineSlideUp,
+        kFineSlideDown,
+        kSetGlissando,
+        kSetVibratoWaveform,
+        kSetFinetune,
+        kLoopPattern,
+        kSetTremoloWaveform,
+        kFineVolSlideUp,
+        kFineVolSlideDown,
+        kDelayPattern,
+        kInvertLoop,
 
-// Lower enum value = higher priority
+        /* The following are not actual MOD effects, but they are useful during conversions */
+        kDutyCycleChange=50,
+        kWavetableChange=51
+    };
+}
+
+uint8_t GetEffectCode(int effect);
+
+// Higher enum value = higher priority
 enum EffectPriority
 {
-    EffectPriorityStructureRelated, /* Can always be performed */
-    EffectPrioritySampleChange, /* Can always be performed */
-    EffectPriorityTempoChange,
-    EffectPriorityPortUp,
-    EffectPriorityPortDown,
-    //EffectPriorityPort2NoteVolSlide,
-    EffectPriorityPort2Note,
-    EffectPriorityVolumeChange,
-    //EffectPriorityVolSlide,
-    EffectPriorityArp,
-    //EffectPriorityVibratoVolSlide,
-    EffectPriorityVibrato,
+    EffectPriorityUnsupportedEffect=0,
     EffectPriorityOtherEffect,
-    EffectPriorityUnsupportedEffect /* Must be the last enum value */
+    EffectPriorityVibrato,
+    //EffectPriorityVibratoVolSlide,
+    EffectPriorityArp,
+    //EffectPriorityVolSlide,
+    EffectPriorityVolumeChange,
+    EffectPriorityPort2Note,
+    //EffectPriorityPort2NoteVolSlide,
+    EffectPriorityPortDown,
+    EffectPriorityPortUp,
+    EffectPriorityTempoChange,
+    EffectPrioritySampleChange, /* Can always be performed */
+    EffectPriorityStructureRelated, /* Can always be performed */
 };
-
-using dmf_sample_id_t = int;
-using mod_sample_id_t = int;
 
 /*
  * MOD has only a 3 octave range while Deflemask has 8.
@@ -107,53 +153,53 @@ class DMFSampleMapper
 public:
     enum class SampleType
     {
-        Silence, Square, Wave
+        kSilence, kSquare, kWave
     };
 
     enum class NoteRange
     {
-        First=0, Second=1, Third=2
+        kFirst=0, kSecond=1, kThird=2
     };
 
     enum class NoteRangeName
     {
-        None=-1, Low=0, Middle=1, High=2
+        kNone=-1, kLow=0, kMiddle=1, kHigh=2
     };
 
     DMFSampleMapper();
 
-    mod_sample_id_t Init(dmf_sample_id_t dmfSampleId, mod_sample_id_t startingId, const std::pair<Note, Note>& dmfNoteRange);
-    mod_sample_id_t InitSilence();
+    SoundIndexType<MOD> Init(SoundIndexType<DMF> dmf_sound_index, SoundIndexType<MOD> starting_sound_index, const std::pair<Note, Note>& dmf_note_range);
+    SoundIndexType<MOD> InitSilence();
 
-    Note GetMODNote(const Note& dmfNote, NoteRange& modNoteRange) const;
-    NoteRange GetMODNoteRange(const Note& dmfNote) const;
-    mod_sample_id_t GetMODSampleId(const Note& dmfNote) const;
-    mod_sample_id_t GetMODSampleId(NoteRange modNoteRange) const;
-    unsigned GetMODSampleLength(NoteRange modNoteRange) const;
-    NoteRange GetMODNoteRange(mod_sample_id_t modSampleId) const;
-    NoteRangeName GetMODNoteRangeName(NoteRange modNoteRange) const;
+    Note GetMODNote(const Note& dmf_note, NoteRange& mod_note_range) const;
+    NoteRange GetMODNoteRange(const Note& dmf_note) const;
+    SoundIndexType<MOD> GetMODSampleId(const Note& dmf_note) const;
+    SoundIndexType<MOD> GetMODSampleId(NoteRange mod_note_range) const;
+    unsigned GetMODSampleLength(NoteRange mod_note_range) const;
+    NoteRange GetMODNoteRange(SoundIndexType<MOD> mod_sound_index) const;
+    NoteRangeName GetMODNoteRangeName(NoteRange mod_note_range) const;
 
-    int GetNumMODSamples() const { return m_NumMODSamples; }
-    SampleType GetSampleType() const { return m_SampleType; }
-    mod_sample_id_t GetFirstMODSampleId() const { return m_ModIds[0]; }
-    bool IsDownsamplingNeeded() const { return m_DownsamplingNeeded; }
+    int GetNumMODSamples() const { return num_mod_samples_; }
+    SampleType GetSampleType() const { return sample_type_; }
+    SoundIndexType<MOD> GetFirstMODSampleId() const { return mod_sound_indexes_[0]; }
+    bool IsDownsamplingNeeded() const { return downsampling_needed_; }
 
 private:
-    dmf_sample_id_t m_DmfId;
-    mod_sample_id_t m_ModIds[3]; // Up to 3 MOD samples from one DMF sample
-    unsigned m_ModSampleLengths[3];
-    std::vector<Note> m_RangeStart;
-    int m_NumMODSamples;
-    SampleType m_SampleType;
-    bool m_DownsamplingNeeded;
-    int m_ModOctaveShift;
+    SoundIndexType<DMF> dmf_sound_index_;
+    SoundIndexType<MOD> mod_sound_indexes_[3]; // Up to 3 MOD samples from one DMF sample
+    unsigned mod_sample_lengths_[3];
+    std::vector<Note> range_start_;
+    int num_mod_samples_;
+    SampleType sample_type_;
+    bool downsampling_needed_;
+    int mod_octave_shift_;
 };
 
 // Stores a MOD sample
 struct Sample
 {
     std::string name; // 22 characters
-    mod_sample_id_t id;
+    SoundIndexType<MOD> id;
     unsigned length;
     int finetune;
     unsigned volume;
@@ -163,112 +209,7 @@ struct Sample
     std::vector<int8_t> data;
 };
 
-using PriorityEffectsMap = std::multimap<mod::EffectPriority, mod::Effect>;
-
-// The current square wave duty cycle, note volume, and other information that the 
-//      tracker stores for each channel while playing a tracker file.
-struct ChannelStateOld
-{
-    enum PORTDIR
-    {
-        PORT_UP, PORT_DOWN
-    };
-
-    int channel;
-    uint16_t dutyCycle;
-    uint16_t wavetable;
-    bool sampleChanged; // MOD sample
-    int16_t volume;
-    bool notePlaying;
-    DMFSampleMapper::NoteRange noteRange;
-    PriorityEffectsMap persistentEffects;
-    int rowsUntilPortAutoOff;
-    PORTDIR portDirection;
-    uint16_t portParam;
-    NoteSlot currentNote; // DMF Note
-};
-
-struct State
-{
-    struct global
-    {
-        bool suspended;      // true == currently in part that a Position Jump skips over
-        int jumpDestination; // DMF pattern matrix row where you are jumping to. Not a loop.
-        Effect channelIndependentEffect;
-        unsigned ticksPerRowPair; // DMF's time_base * (speed_a + speed_b)
-        ChannelIndex channel;    // The current channel in DMF or MOD
-        OrderIndex order;      // The current pattern matrix row in DMF
-        PatternIndex patternRow; // The current pattern row in DMF?
-    } global;
-
-    ChannelStateOld channel[4];
-    ChannelStateOld channelCopy[4];
-
-    Row<MOD> channelRows[4];
-
-    State()
-    {
-        Init(6);
-    }
-
-    State(unsigned ticksPerRowPair)
-    {
-        Init(ticksPerRowPair);
-    }
-
-    void Init(unsigned ticksPerRowPair)
-    {
-        global.suspended = false;
-        global.jumpDestination = -1;
-        global.channelIndependentEffect = {EffectCode::NoEffectCode, EffectCode::NoEffectVal};
-        global.ticksPerRowPair = ticksPerRowPair;
-
-        global.channel = 0;
-        global.order = 0;
-        global.patternRow = 0;
-
-        for (int i = 0; i < 4; i++)
-        {
-            channel[i].channel = i;
-            channel[i].dutyCycle = 0; // Default is 0 or a 12.5% duty cycle square wave.
-            channel[i].wavetable = 0; // Default is wavetable #0.
-            channel[i].sampleChanged = true; // Whether dutyCycle or wavetable recently changed
-            channel[i].volume = dmf::kDMFVolumeMax; // The max volume for a channel (in DMF units)
-            channel[i].notePlaying = false; // Whether a note is currently playing on a channel
-            channel[i].noteRange = DMFSampleMapper::NoteRange::First; // Which MOD sample note range is currently being used
-            channel[i].persistentEffects = {};
-            channel[i].rowsUntilPortAutoOff = -1; // -1 = port not on; 0 = need to turn port off; >0 = rows until port auto off
-            channel[i].portDirection = ChannelStateOld::PORT_UP;
-            channel[i].portParam = 0;
-            channel[i].currentNote = {};
-
-            channelCopy[i] = channel[i];
-            channelRows[i] = {};
-        }
-    }
-
-    void Save(unsigned jumpDestination)
-    {
-        // Save copy of channel states
-        for (int i = 0; i < 4; i++)
-        {
-            channelCopy[i] = channel[i];
-        }
-        global.suspended = true;
-        global.jumpDestination = (int)jumpDestination;
-    }
-
-    void Restore()
-    {
-        // Restore channel states from copy
-        for (int i = 0; i < 4; i++)
-        {
-            channel[i] = channelCopy[i];
-        }
-        global.suspended = false;
-        global.jumpDestination = -1;
-    }
-};
+using PriorityEffect = std::pair<mod::EffectPriority, d2m::Effect>;
 
 } // namespace mod
 
@@ -374,12 +315,12 @@ public:
         MultipleEffects
     };
 
-    static constexpr unsigned VolumeMax = 64u; // Yes, there are 65 different values for the volume
+    static constexpr unsigned kVolumeMax = 64u; // Yes, there are 65 different values for the volume
 
 private:
-    using SampleMap = std::map<mod::dmf_sample_id_t, mod::DMFSampleMapper>;
-    using DMFSampleNoteRangeMap = std::map<mod::dmf_sample_id_t, std::pair<Note, Note>>;
+    using SampleMap = std::map<SoundIndexType<DMF>, mod::DMFSampleMapper>;
 
+    // Module requirements:
     void ImportImpl(const std::string& filename) override;
     void ExportImpl(const std::string& filename) override;
     void ConvertImpl(const ModulePtr& input) override;
@@ -388,18 +329,12 @@ private:
     // Conversion from DMF:
     void ConvertFromDMF(const DMF& dmf);
     void DMFConvertSamples(const DMF& dmf, SampleMap& sampleMap);
-    void DMFCreateSampleMapping(const DMF& dmf, SampleMap& sampleMap, DMFSampleNoteRangeMap& sampleIdLowestHighestNotesMap);
-    void DMFSampleSplittingAndAssignment(SampleMap& sampleMap, const DMFSampleNoteRangeMap& sampleIdLowestHighestNotesMap);
     void DMFConvertSampleData(const DMF& dmf, const SampleMap& sampleMap);
 
-    void DMFConvertPatterns(const DMF& dmf, const SampleMap& sampleMap);
-    mod::PriorityEffectsMap DMFConvertEffects(const Row<DMF>& row, mod::State& state);
-    mod::PriorityEffectsMap DMFConvertEffects_NoiseChannel(const Row<DMF>& row);
-    void DMFUpdateStatePre(const DMF& dmf, mod::State& state, const mod::PriorityEffectsMap& modEffects);
-    void DMFGetAdditionalEffects(const DMF& dmf, mod::State& state, const Row<DMF>& row, mod::PriorityEffectsMap& modEffects);
-    //void DMFUpdateStatePost(const DMF& dmf, mod::State& state, const mod::PriorityEffectsMap& modEffects);
-    Note DMFConvertNote(mod::State& state, const Row<DMF>& row, const SampleMap& sampleMap, mod::PriorityEffectsMap& modEffects, mod::mod_sample_id_t& sampleId, uint16_t& period);
-    Row<MOD> DMFApplyNoteAndEffect(mod::State& state, const mod::PriorityEffectsMap& modEffects, mod::mod_sample_id_t modSampleId, uint16_t period);
+    void DMFConvertPatterns(const DMF& dmf, const SampleMap& sample_map);
+    mod::PriorityEffect DMFConvertEffects(ChannelStateReader<DMF>& state);
+    Row<MOD> DMFConvertNote(ChannelStateReader<DMF>& state, mod::DMFSampleMapper::NoteRange& note_range, bool& note_playing, const SampleMap& sample_map, mod::PriorityEffect& mod_effect);
+    void ApplyEffects(std::array<Row<MOD>, 4>& row_data, const std::array<mod::PriorityEffect, 4>& mod_effect, std::vector<mod::PriorityEffect>& global_effects);
 
     void DMFConvertInitialBPM(const DMF& dmf, unsigned& tempo, unsigned& speed);
 
@@ -413,11 +348,10 @@ private:
 private:
     //////////// Temporaries used during DMF-->MOD conversion
     const bool m_UsingSetupPattern = true; // Whether to use a pattern at the start of the module to set up the initial tempo and other stuff.
-    bool m_DataGenerated; // true = already generated data needed for main conversion loop; false = need to generate data
 
     //////////// MOD file info
     int8_t m_TotalMODSamples;
-    std::map<mod::mod_sample_id_t, mod::Sample> m_Samples;
+    std::map<SoundIndexType<MOD>, mod::Sample> m_Samples;
 };
 
 } // namespace d2m

--- a/include/modules/mod.h
+++ b/include/modules/mod.h
@@ -120,8 +120,6 @@ namespace Effects
     };
 }
 
-uint8_t GetEffectCode(int effect);
-
 // Higher enum value = higher priority
 enum EffectPriority
 {

--- a/src/console/console.cpp
+++ b/src/console/console.cpp
@@ -83,16 +83,17 @@ int main(int argc, char *argv[])
         return 1;
     }
 
-    ////////// IMPORT //////////
-
-    // Import the input file by inferring module type:
-    ModulePtr input = Module::CreateAndImport(io.InputFile);
+    ModulePtr input = Factory<ModuleBase>::Create(io.InputType);
     if (!input)
     {
-        std::cerr << "ERROR: The input module type is not registered.\n";
+        std::cerr << "ERROR: Not enough memory.\n";
         return 1;
     }
 
+    ////////// IMPORT //////////
+
+    // Import the input file by inferring module type:
+    input->Import(io.InputFile);
     if (input->HandleResults())
         return 1;
 
@@ -102,7 +103,7 @@ int main(int argc, char *argv[])
     ModulePtr output = input->Convert(io.OutputType, options);
     if (!output)
     {
-        std::cerr << "ERROR: The output module type is not registered.\n";
+        std::cerr << "ERROR: Not enough memory or input and output types are the same.\n";
         return 1;
     }
 

--- a/src/core/conversion_options.cpp
+++ b/src/core/conversion_options.cpp
@@ -6,6 +6,7 @@
 */
 
 #include "conversion_options.h"
+#include "module_base.h"
 
 #include <iostream>
 

--- a/src/core/module.cpp
+++ b/src/core/module.cpp
@@ -8,6 +8,8 @@
 #include "module.h"
 #include "utils/utils.h"
 
+#include <cassert>
+
 using namespace d2m;
 
 bool ModuleBase::Import(const std::string& filename)
@@ -62,6 +64,7 @@ ModulePtr ModuleBase::Convert(ModuleType type, const ConversionOptionsPtr& optio
     try
     {
         // Perform the conversion
+        assert(shared_from_this() != nullptr);
         output->ConvertImpl(shared_from_this());
     }
     catch (ModuleException& e)

--- a/src/core/module.cpp
+++ b/src/core/module.cpp
@@ -10,20 +10,6 @@
 
 using namespace d2m;
 
-ModulePtr ModuleBase::CreateAndImport(const std::string& filename)
-{
-    const ModuleType type = Utils::GetTypeFromFilename(filename);
-    if (type == ModuleType::NONE)
-        return nullptr;
-
-    ModulePtr m = Factory<ModuleBase>::Create(type);
-    if (!m)
-        return nullptr;
-
-    m->Import(filename);
-    return m;
-}
-
 bool ModuleBase::Import(const std::string& filename)
 {
     m_Status.Reset(Status::Category::Import);

--- a/src/core/module.cpp
+++ b/src/core/module.cpp
@@ -20,15 +20,7 @@ ModulePtr ModuleBase::CreateAndImport(const std::string& filename)
     if (!m)
         return nullptr;
 
-    try
-    {
-        m->Import(filename);
-    }
-    catch (ModuleException& e)
-    {
-        m->m_Status.AddError(std::move(e));
-    }
-
+    m->Import(filename);
     return m;
 }
 

--- a/src/core/module.cpp
+++ b/src/core/module.cpp
@@ -37,7 +37,7 @@ bool ModuleBase::Import(const std::string& filename)
     m_Status.Reset(Status::Category::Import);
     try
     {
-        ImportRaw(filename);
+        ImportImpl(filename);
         return false;
     }
     catch (ModuleException& e)
@@ -53,7 +53,7 @@ bool ModuleBase::Export(const std::string& filename)
     m_Status.Reset(Status::Category::Export);
     try
     {
-        ExportRaw(filename);
+        ExportImpl(filename);
         return false;
     }
     catch (ModuleException& e)
@@ -84,7 +84,7 @@ ModulePtr ModuleBase::Convert(ModuleType type, const ConversionOptionsPtr& optio
     try
     {
         // Perform the conversion
-        output->ConvertRaw(shared_from_this());
+        output->ConvertImpl(shared_from_this());
     }
     catch (ModuleException& e)
     {

--- a/src/core/status.cpp
+++ b/src/core/status.cpp
@@ -18,9 +18,9 @@ void Status::PrintError(bool useStdErr) const
         return;
 
     if (useStdErr)
-        std::cerr << m_Error.second.what() << "\n";
+        std::cerr << m_Error.value().what() << "\n";
     else
-        std::cout << m_Error.second.what() << "\n";
+        std::cout << m_Error.value().what() << "\n";
 }
 
 void Status::PrintWarnings(bool useStdErr) const

--- a/src/core/status.cpp
+++ b/src/core/status.cpp
@@ -18,9 +18,9 @@ void Status::PrintError(bool useStdErr) const
         return;
 
     if (useStdErr)
-        std::cerr << m_Error.value().what() << "\n";
+        std::cerr << m_Error->what() << "\n";
     else
-        std::cout << m_Error.value().what() << "\n";
+        std::cout << m_Error->what() << "\n";
 }
 
 void Status::PrintWarnings(bool useStdErr) const

--- a/src/modules/dmf.cpp
+++ b/src/modules/dmf.cpp
@@ -843,7 +843,129 @@ int DMF::GetRowsUntilPortDownAutoOff(unsigned ticksPerRowPair, const NoteSlot& n
     return static_cast<int>(std::max(std::ceil((lowestPeriod - GetPeriod(GetNote(note))) / ((ticksPerRowPair / 2.0) * portDownParam)), 1.0));
 }
 
-size_t dmf::GenerateDataImpl(DMF const* dmf, ModuleGeneratedDataMethods<DMF>* data)
+size_t dmf::GenerateDataImpl(DMF const* dmf, ModuleGeneratedDataMethods<DMF>* genData)
 {
-    return 0; // Not impl yet
+    if (!dmf || !genData)
+        return 0;
+
+    // Currently can only generate data for the Game Boy system
+    if (dmf->GetSystem().type != System::Type::GameBoy)
+        return 0;
+
+    genData->GetState() = ModuleState<DMF>{}; // Give generated data a state object
+    auto& stateData = genData->GetState().value();
+    stateData.Initialize(dmf->GetSystem().channels);
+
+    auto globalState = stateData.GetGlobalReaderWriter();
+    //using state_data_t = GlobalStateReaderWriter<DMF>::state_data_t;
+
+    const auto& data = dmf->GetData();
+    for (channel_index_t channel = 0; channel < data.GetNumChannels(); ++channel)
+    {
+        auto channelState = stateData.GetChannelReaderWriter(channel);
+        for (order_index_t order = 0; order < data.GetNumOrders(); ++order)
+        {
+            for (row_index_t row = 0; row < data.GetNumRows(); ++row)
+            {
+                const auto& rowData = data.GetRow(channel, order, row);
+
+                /*
+
+                // If just arrived at jump destination:
+                if (static_cast<int>(dmfOrder) == state.global.jumpDestination && row == 0 && state.global.suspended)
+                {
+                    // Restore state copies
+                    state.Restore();
+                }
+
+                PriorityEffectsMap modEffects;
+                //mod_sample_id_t modSampleId = 0;
+                //uint16_t period = 0;
+
+                if (channel == static_cast<channel_index_t>(dmf::GameBoyChannel::NOISE))
+                {
+                    modEffects = DMFConvertEffects_NoiseChannel(chanRow);
+                    DMFUpdateStatePre(dmf, state, modEffects);
+                    continue;
+                }
+
+                modEffects = DMFConvertEffects(chanRow, state);
+                DMFUpdateStatePre(dmf, state, modEffects);
+                DMFGetAdditionalEffects(dmf, state, chanRow, modEffects);
+
+                //DMFConvertNote(state, chanRow, sampleMap, modEffects, modSampleId, period);
+
+                // TODO: More state-related stuff could be extracted from DMFConvertNote and put into separate 
+                //  method so that I don't have to copy code from it to put here.
+
+                // Convert note - Note cut effect
+                auto sampleChangeEffects = modEffects.equal_range(EffectPrioritySampleChange);
+                if (sampleChangeEffects.first != sampleChangeEffects.second) // If sample change occurred (duty cycle, wave, or note cut effect)
+                {
+                    for (auto& iter = sampleChangeEffects.first; iter != sampleChangeEffects.second; )
+                    {
+                        Effect& modEffect = iter->second;
+                        if (modEffect.effect == EffectCode::CutSample && modEffect.value == 0) // Note cut
+                        {
+                            // Silent sample is needed
+                            if (sampleMap.count(-1) == 0)
+                                sampleMap[-1] = {};
+
+                            chanState.notePlaying = false;
+                            chanState.currentNote = {};
+                            iter = modEffects.erase(iter); // Consume the effect
+                        }
+                        else
+                        {
+                            // Only increment if an element wasn't erased
+                            ++iter;
+                        }
+                    }
+                }
+
+                // Convert note - Note OFF
+                if (NoteIsOff(chanRow.note)) // Note OFF. Use silent sample and handle effects.
+                {
+                    chanState.notePlaying = false;
+                    chanState.currentNote = NoteTypes::Off{};
+                }
+
+                // A note on the SQ1, SQ2, or WAVE channels:
+                if (NoteHasPitch(chanRow.note) && chan != dmf::GameBoyChannel::NOISE)
+                {
+                    const Note& dmfNote = GetNote(chanRow.note);
+                    chanState.notePlaying = true;
+                    chanState.currentNote = chanRow.note;
+
+                    mod_sample_id_t sampleId = chan == dmf::GameBoyChannel::WAVE ? chanState.wavetable + 4 : chanState.dutyCycle;
+
+                    // Mark this square wave or wavetable as used
+                    sampleMap[sampleId] = {};
+
+                    // Get lowest/highest notes
+                    if (sampleIdLowestHighestNotesMap.count(sampleId) == 0) // 1st time
+                    {
+                        sampleIdLowestHighestNotesMap[sampleId] = { dmfNote, dmfNote };
+                    }
+                    else
+                    {
+                        auto& notePair = sampleIdLowestHighestNotesMap[sampleId];
+                        if (dmfNote > notePair.second)
+                        {
+                            // Found a new highest note
+                            notePair.second = dmfNote;
+                        }
+                        if (dmfNote < notePair.first)
+                        {
+                            // Found a new lowest note
+                            notePair.first = dmfNote;
+                        }
+                    }
+                }
+                */
+            }
+        }
+    }
+
+    return 0;
 }

--- a/src/modules/dmf.cpp
+++ b/src/modules/dmf.cpp
@@ -710,40 +710,40 @@ Row<DMF> DMF::LoadPatternRow(Reader& fin, uint8_t effectsColumnsCount)
         EffectCode effect_code = Effects::kNoEffect;
         switch (dmf_effect_code)
         {
-            case EffectCode::kNoEffect:             effect_code = Effects::kNoEffect; break;
-            case EffectCode::kArp:                  effect_code = Effects::kArp; break;
-            case EffectCode::kPortUp:               effect_code = Effects::kPortUp; break;
-            case EffectCode::kPortDown:             effect_code = Effects::kPortDown; break;
-            case EffectCode::kPort2Note:            effect_code = Effects::kPort2Note; break;
-            case EffectCode::kVibrato:              effect_code = Effects::kVibrato; break;
-            case EffectCode::kPort2NoteVolSlide:    effect_code = Effects::kPort2NoteVolSlide; break;
-            case EffectCode::kVibratoVolSlide:      effect_code = Effects::kVibratoVolSlide; break;
-            case EffectCode::kTremolo:              effect_code = Effects::kTremolo; break;
-            case EffectCode::kPanning:              effect_code = Effects::kPanning; break;
-            case EffectCode::kSetSpeedVal1:         effect_code = Effects::kSpeedA; break;
-            case EffectCode::kVolSlide:             effect_code = Effects::kVolSlide; break;
-            case EffectCode::kPosJump:              effect_code = Effects::kPosJump; break;
-            case EffectCode::kRetrig:               effect_code = Effects::kRetrigger; break;
-            case EffectCode::kPatBreak:             effect_code = Effects::kPatBreak; break;
-            case EffectCode::kArpTickSpeed:         effect_code = dmf::Effects::kArpTickSpeed; break;
-            case EffectCode::kNoteSlideUp:          effect_code = dmf::Effects::kNoteSlideUp; break;
-            case EffectCode::kNoteSlideDown:        effect_code = dmf::Effects::kNoteSlideDown; break;
-            case EffectCode::kSetVibratoMode:       effect_code = dmf::Effects::kSetVibratoMode; break;
-            case EffectCode::kSetFineVibratoDepth:  effect_code = dmf::Effects::kSetFineVibratoDepth; break;
-            case EffectCode::kSetFinetune:          effect_code = dmf::Effects::kSetFinetune; break;
-            case EffectCode::kSetSamplesBank:       effect_code = dmf::Effects::kSetSamplesBank; break;
-            case EffectCode::kNoteCut:              effect_code = Effects::kNoteCut; break;
-            case EffectCode::kNoteDelay:            effect_code = Effects::kNoteDelay; break;
-            case EffectCode::kSyncSignal:           effect_code = dmf::Effects::kSyncSignal; break;
-            case EffectCode::kSetGlobalFinetune:    effect_code = dmf::Effects::kSetGlobalFinetune; break;
-            case EffectCode::kSetSpeedVal2:         effect_code = Effects::kSpeedB; break;
+            case dmf::EffectCode::kNoEffect:             effect_code = Effects::kNoEffect; break;
+            case dmf::EffectCode::kArp:                  effect_code = Effects::kArp; break;
+            case dmf::EffectCode::kPortUp:               effect_code = Effects::kPortUp; break;
+            case dmf::EffectCode::kPortDown:             effect_code = Effects::kPortDown; break;
+            case dmf::EffectCode::kPort2Note:            effect_code = Effects::kPort2Note; break;
+            case dmf::EffectCode::kVibrato:              effect_code = Effects::kVibrato; break;
+            case dmf::EffectCode::kPort2NoteVolSlide:    effect_code = Effects::kPort2NoteVolSlide; break;
+            case dmf::EffectCode::kVibratoVolSlide:      effect_code = Effects::kVibratoVolSlide; break;
+            case dmf::EffectCode::kTremolo:              effect_code = Effects::kTremolo; break;
+            case dmf::EffectCode::kPanning:              effect_code = Effects::kPanning; break;
+            case dmf::EffectCode::kSetSpeedVal1:         effect_code = Effects::kSpeedA; break;
+            case dmf::EffectCode::kVolSlide:             effect_code = Effects::kVolSlide; break;
+            case dmf::EffectCode::kPosJump:              effect_code = Effects::kPosJump; break;
+            case dmf::EffectCode::kRetrig:               effect_code = Effects::kRetrigger; break;
+            case dmf::EffectCode::kPatBreak:             effect_code = Effects::kPatBreak; break;
+            case dmf::EffectCode::kArpTickSpeed:         effect_code = dmf::Effects::kArpTickSpeed; break;
+            case dmf::EffectCode::kNoteSlideUp:          effect_code = dmf::Effects::kNoteSlideUp; break;
+            case dmf::EffectCode::kNoteSlideDown:        effect_code = dmf::Effects::kNoteSlideDown; break;
+            case dmf::EffectCode::kSetVibratoMode:       effect_code = dmf::Effects::kSetVibratoMode; break;
+            case dmf::EffectCode::kSetFineVibratoDepth:  effect_code = dmf::Effects::kSetFineVibratoDepth; break;
+            case dmf::EffectCode::kSetFinetune:          effect_code = dmf::Effects::kSetFinetune; break;
+            case dmf::EffectCode::kSetSamplesBank:       effect_code = dmf::Effects::kSetSamplesBank; break;
+            case dmf::EffectCode::kNoteCut:              effect_code = Effects::kNoteCut; break;
+            case dmf::EffectCode::kNoteDelay:            effect_code = Effects::kNoteDelay; break;
+            case dmf::EffectCode::kSyncSignal:           effect_code = dmf::Effects::kSyncSignal; break;
+            case dmf::EffectCode::kSetGlobalFinetune:    effect_code = dmf::Effects::kSetGlobalFinetune; break;
+            case dmf::EffectCode::kSetSpeedVal2:         effect_code = Effects::kSpeedB; break;
 
             // Game Boy exclusive:
-            case EffectCode::kGameBoySetWave:                   effect_code = dmf::Effects::kGameBoySetWave; break;
-            case EffectCode::kGameBoySetNoisePolyCounterMode:   effect_code = dmf::Effects::kGameBoySetNoisePolyCounterMode; break;
-            case EffectCode::kGameBoySetDutyCycle:              effect_code = dmf::Effects::kGameBoySetDutyCycle; break;
-            case EffectCode::kGameBoySetSweepTimeShift:         effect_code = dmf::Effects::kGameBoySetSweepTimeShift; break;
-            case EffectCode::kGameBoySetSweepDir:               effect_code = dmf::Effects::kGameBoySetSweepDir; break;
+            case dmf::EffectCode::kGameBoySetWave:                   effect_code = dmf::Effects::kGameBoySetWave; break;
+            case dmf::EffectCode::kGameBoySetNoisePolyCounterMode:   effect_code = dmf::Effects::kGameBoySetNoisePolyCounterMode; break;
+            case dmf::EffectCode::kGameBoySetDutyCycle:              effect_code = dmf::Effects::kGameBoySetDutyCycle; break;
+            case dmf::EffectCode::kGameBoySetSweepTimeShift:         effect_code = dmf::Effects::kGameBoySetSweepTimeShift; break;
+            case dmf::EffectCode::kGameBoySetSweepDir:               effect_code = dmf::Effects::kGameBoySetSweepDir; break;
 
             default:
                 // Set a warning here? (unable to parse effect code)

--- a/src/modules/dmf.cpp
+++ b/src/modules/dmf.cpp
@@ -992,30 +992,28 @@ size_t DMF::GenerateDataImpl(size_t data_flags) const
 
     // Set initial state (global)
     global_state.Reset(); // Just in case
-    global_state.SetWritePos(-1); // Initial state
-    global_state.Set<GlobalCommon::kSpeedA>(m_ModuleInfo.tickTime1); // * timebase?
-    global_state.Set<GlobalCommon::kSpeedB>(m_ModuleInfo.tickTime2); // * timebase?
-    global_state.Set<GlobalCommon::kTempo>(0); // TODO: How should tempo/speed info be stored?
+    global_state.SetInitial<GlobalCommon::kSpeedA>(m_ModuleInfo.tickTime1); // * timebase?
+    global_state.SetInitial<GlobalCommon::kSpeedB>(m_ModuleInfo.tickTime2); // * timebase?
+    global_state.SetInitial<GlobalCommon::kTempo>(0); // TODO: How should tempo/speed info be stored?
 
     // Set initial state (per-channel)
     for (unsigned i = 0; i < channel_states.size(); ++i)
     {
         auto& channel_state = channel_states[i];
         channel_state.Reset(); // Just in case
-        channel_state.SetWritePos(-1); // Initial state
 
-        channel_state.Set<ChannelCommon::kSoundIndex>(current_sound_index[i].second);
-        channel_state.Set<ChannelCommon::kNoteSlot>(NoteTypes::Empty{});
-        channel_state.Set<ChannelCommon::kNotePlaying>(false);
-        channel_state.Set<ChannelCommon::kVolume>(kDMFGameBoyVolumeMax);
-        channel_state.Set<ChannelCommon::kArp>(0);
-        channel_state.Set<ChannelCommon::kPort>({PortamentoStateData::kNone, 0});
-        channel_state.Set<ChannelCommon::kVibrato>(0);
-        channel_state.Set<ChannelCommon::kPort2NoteVolSlide>(0);
-        channel_state.Set<ChannelCommon::kVibratoVolSlide>(0);
-        channel_state.Set<ChannelCommon::kTremolo>(0);
-        channel_state.Set<ChannelCommon::kPanning>(127);
-        channel_state.Set<ChannelCommon::kVolSlide>(0);
+        channel_state.SetInitial<ChannelCommon::kSoundIndex>(current_sound_index[i].second);
+        channel_state.SetInitial<ChannelCommon::kNoteSlot>(NoteTypes::Empty{});
+        channel_state.SetInitial<ChannelCommon::kNotePlaying>(false);
+        channel_state.SetInitial<ChannelCommon::kVolume>(kDMFGameBoyVolumeMax);
+        channel_state.SetInitial<ChannelCommon::kArp>(0);
+        channel_state.SetInitial<ChannelCommon::kPort>({PortamentoStateData::kNone, 0});
+        channel_state.SetInitial<ChannelCommon::kVibrato>(0);
+        channel_state.SetInitial<ChannelCommon::kPort2NoteVolSlide>(0);
+        channel_state.SetInitial<ChannelCommon::kVibratoVolSlide>(0);
+        channel_state.SetInitial<ChannelCommon::kTremolo>(0);
+        channel_state.SetInitial<ChannelCommon::kPanning>(127);
+        channel_state.SetInitial<ChannelCommon::kVolSlide>(0);
     }
 
     // Main loop

--- a/src/modules/dmf.cpp
+++ b/src/modules/dmf.cpp
@@ -1274,7 +1274,7 @@ size_t DMF::GenerateDataImpl(size_t dataFlags) const
                 {
                     channel_state.Set<ChannelCommon::kNoteSlot>(note_slot);
                 }
-                if (NoteIsOff(note_slot))
+                else if (NoteIsOff(note_slot))
                 {
                     channel_state.Set<ChannelCommon::kNoteSlot>(note_slot);
                     gen_data.Get<GenDataEnumCommon::kNoteOffUsed>() = true;
@@ -1282,7 +1282,6 @@ size_t DMF::GenerateDataImpl(size_t dataFlags) const
                 }
                 else if (NoteHasPitch(note_slot) && channel != dmf::GameBoyChannel::NOISE && !note_cancelled[channel])
                 {
-                    // NoteTypes::Empty should never appear in state data (but can in initial state)
                     channel_state.Set<ChannelCommon::kNoteSlot, true>(note_slot);
                     const Note& note = GetNote(note_slot);
 
@@ -1355,7 +1354,8 @@ size_t DMF::GenerateDataImpl(size_t dataFlags) const
                     // Want to check all channels to update the global state for this row
                     for (ChannelIndex channel2 = 0; channel2 < data.GetNumChannels(); ++channel2)
                     {
-                        for (const auto& effect : row_data.effect)
+                        const auto& row_data2 = data.GetRow(channel2, order, row);
+                        for (const auto& effect : row_data2.effect)
                         {
                             switch (effect.code)
                             {
@@ -1368,6 +1368,7 @@ size_t DMF::GenerateDataImpl(size_t dataFlags) const
                                         break;
                                     }
                                     pos_jump = effect.value;
+                                    ignore_pos_jump = true;
                                     break;
                                 case Effects::kPatBreak:
                                     if (ignore_pat_break)
@@ -1378,6 +1379,7 @@ size_t DMF::GenerateDataImpl(size_t dataFlags) const
                                         break;
                                     }
                                     pat_break = effect.value;
+                                    ignore_pat_break = true;
                                     break;
                                 case Effects::kSpeedA:
                                     // TODO

--- a/src/modules/dmf.cpp
+++ b/src/modules/dmf.cpp
@@ -863,7 +863,10 @@ double DMF::GetBPM() const
  * 1:  MOD-compatible portamentos (no port2note auto-off, ...)
  * 2:  MOD-compatible loops (notes, sound index, and channel volume carry over)
  *      Adds a Note OFF to loopback points if needed
- *      Returns 2 flag if an extra "loopback order" would be needed (?)
+ * Return flags:
+ * 0:  Success
+ * 1:  Error
+ * 2:  An extra "loopback order" is needed
  */
 size_t DMF::GenerateDataImpl(size_t data_flags) const
 {
@@ -873,9 +876,6 @@ size_t DMF::GenerateDataImpl(size_t data_flags) const
     // Currently can only generate data for the Game Boy system
     if (GetSystem().type != System::Type::GameBoy)
         return 1;
-
-    // Clear all generated data
-    gen_data.ClearAll();
 
     // Initialize state
     auto& state_data = gen_data.GetState().emplace();

--- a/src/modules/dmf.cpp
+++ b/src/modules/dmf.cpp
@@ -839,3 +839,8 @@ int DMF::GetRowsUntilPortDownAutoOff(unsigned ticksPerRowPair, const NoteSlot& n
     constexpr double lowestPeriod = GetPeriod({NotePitch::C, 2}); // C-2
     return static_cast<int>(std::max(std::ceil((lowestPeriod - GetPeriod(GetNote(note))) / ((ticksPerRowPair / 2.0) * portDownParam)), 1.0));
 }
+
+size_t dmf::GenerateDataImpl(DMF const* dmf, ModuleGeneratedDataMethods<DMF>* data)
+{
+    return 0; // Not impl yet
+}

--- a/src/modules/mod.cpp
+++ b/src/modules/mod.cpp
@@ -429,7 +429,7 @@ void MOD::DMFConvertPatterns(const DMF& dmf, const SampleMap& sample_map)
             // Global effects, highest priority first:
 
             if (global_reader.GetOneShotDelta(GlobalState<DMF>::kPatBreak))
-                global_effects.push_back({ EffectPriorityStructureRelated, { Effects::kPatBreak, global_reader.GetOneShot<GlobalState<DMF>::kPatBreak>() } });
+                global_effects.push_back({ EffectPriorityStructureRelated, { Effects::kPatBreak, static_cast<EffectValue>(global_reader.GetOneShot<GlobalState<DMF>::kPatBreak>()) } });
             else if (dmf_num_rows < 64 && dmf_row + 1 == dmf_num_rows)
                 global_effects.push_back({ EffectPriorityStructureRelated, { Effects::kPatBreak, 0 } });  // Use PatBreak to allow patterns under 64 rows
 

--- a/src/modules/mod.cpp
+++ b/src/modules/mod.cpp
@@ -53,13 +53,13 @@ MOD::MOD()
     m_DataGenerated = false;
 }
 
-void MOD::ImportRaw(const std::string& filename)
+void MOD::ImportImpl(const std::string& filename)
 {
     // Not implemented
     throw NotImplementedException();
 }
 
-void MOD::ConvertRaw(const ModulePtr& input)
+void MOD::ConvertImpl(const ModulePtr& input)
 {
     if (!input)
     {
@@ -1612,7 +1612,7 @@ DMFSampleMapper::NoteRangeName DMFSampleMapper::GetMODNoteRangeName(NoteRange mo
 
 ///////// EXPORT /////////
 
-void MOD::ExportRaw(const std::string& filename)
+void MOD::ExportImpl(const std::string& filename)
 {
     std::ofstream outFile(filename, std::ios::binary);
     if (!outFile.is_open())

--- a/src/modules/mod.cpp
+++ b/src/modules/mod.cpp
@@ -30,6 +30,7 @@ using MODOptionEnum = MODConversionOptions::OptionEnum;
 
 static std::vector<int8_t> GenerateSquareWaveSample(unsigned dutyCycle, unsigned length);
 static std::vector<int8_t> GenerateWavetableSample(uint32_t* wavetableData, unsigned length);
+static inline uint8_t GetEffectCode(int effect_code);
 
 static std::string GetWarningMessage(MOD::ConvertWarning warning, const std::string& info = "");
 
@@ -776,10 +777,86 @@ void MOD::DMFConvertInitialBPM(const DMF& dmf, unsigned& tempo, unsigned& speed)
         m_Status.AddWarning(GetWarningMessage(ConvertWarning::TempoAccuracy));
 }
 
-uint8_t mod::GetEffectCode(int effect)
+static inline uint8_t GetEffectCode(int effect_code)
 {
-    // TODO: Implement this. Maps dmf2mod internal effect code to MOD effect code.
-    return 0;
+    // Maps dmf2mod internal effect code to MOD effect code.
+    switch (effect_code)
+    {
+        // Common effects:
+        case d2m::Effects::kNoEffect:
+            return mod::EffectCode::kNoEffect;
+        case d2m::Effects::kArp:
+            return mod::EffectCode::kArp;
+        case d2m::Effects::kPortUp:
+            return mod::EffectCode::kPortUp;
+        case d2m::Effects::kPortDown:
+            return mod::EffectCode::kPortDown;
+        case d2m::Effects::kPort2Note:
+            return mod::EffectCode::kPort2Note;
+        case d2m::Effects::kVibrato:
+            return mod::EffectCode::kVibrato;
+        case d2m::Effects::kPort2NoteVolSlide:
+            return mod::EffectCode::kPort2NoteVolSlide;
+        case d2m::Effects::kVibratoVolSlide:
+            return mod::EffectCode::kVibratoVolSlide;
+        case d2m::Effects::kTremolo:
+            return mod::EffectCode::kTremolo;
+        case d2m::Effects::kPanning:
+            return mod::EffectCode::kPanning;
+        case d2m::Effects::kSpeedA:
+            return mod::EffectCode::kSetSpeed;
+        case d2m::Effects::kVolSlide:
+            return mod::EffectCode::kVolSlide;
+        case d2m::Effects::kPosJump:
+            return mod::EffectCode::kPosJump;
+        case d2m::Effects::kRetrigger:
+            return mod::EffectCode::kRetriggerSample;
+        case d2m::Effects::kPatBreak:
+            return mod::EffectCode::kPatBreak;
+        case d2m::Effects::kNoteCut:
+            return mod::EffectCode::kCutSample;
+        case d2m::Effects::kNoteDelay:
+            return mod::EffectCode::kDelaySample;
+        case d2m::Effects::kTempo:
+            return mod::EffectCode::kSetSpeed; // Same as kSpeedA, but different effect values are used
+        case d2m::Effects::kSpeedB:
+            assert(0 && "Unsupported effect");
+            return mod::EffectCode::kNoEffect;
+
+        // ProTracker-specific effects:
+        case mod::Effects::kSetSampleOffset:
+            return mod::EffectCode::kSetSampleOffset;
+        case mod::Effects::kSetVolume:
+            return mod::EffectCode::kSetVolume;
+        case mod::Effects::kSetFilter:
+            return mod::EffectCode::kSetFilter;
+        case mod::Effects::kFineSlideUp:
+            return mod::EffectCode::kFineSlideUp;
+        case mod::Effects::kFineSlideDown:
+            return mod::EffectCode::kFineSlideDown;
+        case mod::Effects::kSetGlissando:
+            return mod::EffectCode::kSetGlissando;
+        case mod::Effects::kSetVibratoWaveform:
+            return mod::EffectCode::kSetVibratoWaveform;
+        case mod::Effects::kSetFinetune:
+            return mod::EffectCode::kSetFinetune;
+        case mod::Effects::kLoopPattern:
+            return mod::EffectCode::kLoopPattern;
+        case mod::Effects::kSetTremoloWaveform:
+            return mod::EffectCode::kSetTremoloWaveform;
+        case mod::Effects::kFineVolSlideUp:
+            return mod::EffectCode::kFineVolSlideUp;
+        case mod::Effects::kFineVolSlideDown:
+            return mod::EffectCode::kFineVolSlideDown;
+        case mod::Effects::kDelayPattern:
+            return mod::EffectCode::kDelayPattern;
+        case mod::Effects::kInvertLoop:
+            return mod::EffectCode::kInvertLoop;
+
+        default:
+            assert(0 && "Unknown effect");
+            return mod::EffectCode::kNoEffect;
+    }
 }
 
 ///// DMF --> MOD Sample Mapper

--- a/src/modules/mod.cpp
+++ b/src/modules/mod.cpp
@@ -576,6 +576,14 @@ Row<MOD> MOD::DMFConvertNote(ChannelStateReader<DMF>& state, mod::DMFSampleMappe
 
     Row<MOD> row_data{};
 
+    if (!state.GetDelta(ChannelState<DMF>::kNoteSlot))
+    {
+        // This is actually an Empty note slot
+        row_data.sample = 0; // Keeps previous sample id
+        row_data.note = NoteTypes::Empty{};
+        return row_data;
+    }
+
     NoteSlot dmf_note = state.Get<ChannelState<DMF>::kNoteSlot>();
     switch (dmf_note.index())
     {
@@ -587,13 +595,6 @@ Row<MOD> MOD::DMFConvertNote(ChannelStateReader<DMF>& state, mod::DMFSampleMappe
 
         // Convert note - Note OFF
         case NoteTypes::kOff:
-            if (!state.GetDelta(ChannelState<DMF>::kNoteSlot))
-            {
-                // This is actually an Empty note slot
-                row_data.sample = 0; // Keeps previous sample id
-                row_data.note = NoteTypes::Empty{};
-                return row_data;
-            }
             row_data.sample = 1; // Use silent sample (always sample #1 if it is used)
             row_data.note = dmf_note; // Don't need a note for the silent sample to work
             set_sample = false;
@@ -603,14 +604,6 @@ Row<MOD> MOD::DMFConvertNote(ChannelStateReader<DMF>& state, mod::DMFSampleMappe
         // Convert note - Note with pitch
         case NoteTypes::kNote:
         {
-            if (!state.GetDelta(ChannelState<DMF>::kNoteSlot))
-            {
-                // This is actually an Empty note slot
-                row_data.sample = 0; // Keeps previous sample id
-                row_data.note = NoteTypes::Empty{};
-                return row_data;
-            }
-
             const SoundIndexType<DMF>& dmf_sound_index = state.Get<ChannelState<DMF>::kSoundIndex>();
             const DMFSampleMapper& sample_mapper = sample_map.at(dmf_sound_index);
 

--- a/src/modules/mod.cpp
+++ b/src/modules/mod.cpp
@@ -1714,15 +1714,17 @@ void MOD::ExportSampleInfo(std::ofstream& fout) const
 
 void MOD::ExportModuleInfo(std::ofstream& fout) const
 {
-    fout.put(GetData().GetNumOrders());   // Song length in patterns (not total number of patterns) 
-    fout.put(127);                        // 0x7F - Useless byte that has to be here
+    const uint8_t numOrders = static_cast<uint8_t>(GetData().GetNumOrders());
+
+    fout.put(numOrders); // Song length in patterns (not total number of patterns)
+    fout.put(127);       // 0x7F - Useless byte that has to be here
 
     // Pattern matrix (Each ProTracker pattern number is the same as its pattern matrix row number)
-    for (uint8_t patternId : GetData().PatternMatrixRef())
+    for (pattern_index_t patternId : GetData().PatternMatrixRef())
     {
-        fout.put(patternId);
+        fout.put(static_cast<uint8_t>(patternId));
     }
-    for (uint8_t i = GetData().GetNumOrders(); i < 128; ++i)
+    for (uint8_t i = numOrders; i < 128; ++i)
     {
         fout.put(0);
     }

--- a/src/webapp/webapp.cpp
+++ b/src/webapp/webapp.cpp
@@ -118,7 +118,7 @@ bool ModuleImport(std::string filename)
     {
         std::cerr << "Error during import:\n";
         std::cerr << "ERROR: Not enough memory.\n";
-        return 1;
+        return true;
     }
 
     G_Module->Import(filename);

--- a/src/webapp/webapp.cpp
+++ b/src/webapp/webapp.cpp
@@ -103,7 +103,9 @@ std::vector<OptionDefinitionWrapper> GetOptionDefinitionsWrapper(int moduleType)
 bool ModuleImport(std::string filename)
 {
     SetStatusType(true);
-    if (Utils::GetTypeFromFilename(filename) == ModuleType::NONE)
+
+    const ModuleType input_type = Utils::GetTypeFromFilename(filename);
+    if (input_type == ModuleType::NONE)
     {
         std::cerr << "The input file is not recognized as a supported module type.\n\n";
         return true;
@@ -111,13 +113,15 @@ bool ModuleImport(std::string filename)
 
     G_InputFilename = filename;
 
-    G_Module = Module::CreateAndImport(filename);
+    G_Module = Factory<ModuleBase>::Create(input_type);
     if (!G_Module)
     {
         std::cerr << "Error during import:\n";
-        std::cerr << "ERROR: The module type may not be registered.\n\n";
-        return true;
+        std::cerr << "ERROR: Not enough memory.\n";
+        return 1;
     }
+
+    G_Module->Import(filename);
 
     if (G_Module->GetStatus().ErrorOccurred())
     {


### PR DESCRIPTION
Major refactoring work which adds generated data.

### Generated data includes:
- State data
  - Global state data
    - regular
    - one-shot
  - Per-channel state data
    - regular
    - one-shot
- Sound indexes used
- Sound index note extremes
- Channel note extremes
- Note OFF used

These are the "common" generated data types defined in the dmf2mod core, but custom data types can easily be added.

State data is an evolved version of the ugly "state" system previously implemented in mod.h/mod.cpp.
It offers many improvements. It provides a module-independent state representation, is customizable, and provides reader/writer classes which abstract away the details of interacting with it and provide a safe, easy-to-use interface. Importantly, it stores all the state information permanently rather than just the current state temporarily like before. This means that things like the channel volume, what note is playing, or other state information at any point in a song can be quickly and easily queried. For DMF->MOD conversions, the state is written to by the DMF class upon request by the MOD class, then MOD reads from the state during its conversion process. All Deflemask quirks are handled by DMF while writing the state, so the state read by other modules is a simple quirk-free intermediate representation. This greatly simplifies the conversion process on the MOD side (and in any future supported modules) by leaving DMF to handle all the Deflemask quirks.

Some state data mirrors the data stored in ModuleData, but in a different form. Both ModuleData and State data store notes, effects, etc. used at any given point in a song, but the State data often does not store exactly the same information, and it represents it in a way suitable for conversions to other formats. Unlike ModuleData, State data ***cannot*** be used to reconstruct a module file exactly as the original was, since State data (ideally) does not store any information which is unnecessary to understanding the way a module is supposed to sound. Because of this, the State could potentially be used to simplify module files by trimming away unused samples/instruments, unused patterns, effects that don't do anything, unused effect columns, orders and parts of orders that are skipped over by PosJump/PatBreak effects, and adding good practice choices like stopping a portamento before it reaches its min/max pitch rather than relying on quirky behavior, etc. ModuleData stores the data as it appears in the original module file, while State stores data in a concise behavior-focused way which is independent of the original module file's way of doing things.

Regular state data consists of a vector of order/row position and a data value pairs. The data stays at whatever value it is at until it changes. Only these changes are stored by the State in the vectors. Regular state data must be given an initial state. Examples of regular state data include the channel volume, effects, and what note is playing.
One-shot state data also consists of a vector of order/row position and a data value pairs, but instead of storing a continuous state which is held until it changes, it instead holds one-time events. Examples of one-shot state data include position jumps, note cuts, and pattern breaks.
Regular state data has methods to "save" and "restore" state data when position jumps and pattern breaks occur, but one-shot state data does not. Reading/writing regular vs one-shot state data is mostly the same but does have some differences.

While there are "common" generated data types and state data types which would be broadly useful for most module file types out there, there is also the ability to easily add your own custom generated data and state data types if a module requires it.

### Other changes worth noting:
- Unified effects - An internal module-independent way of handling effects is now being used.
- Full pattern break support has been added
- Note cut support has been removed (it never worked correctly anyway)
- Portamento conversion improved
  - Deflemask quirks relating to portamentos - which ones have priority over others, behavior based on the effect column, etc. are now more accurately handled
  - Automatic portamento off is handled in a simpler way
  - Automatic portamento off should handle some edge cases better - such as switching from port up to port down without a note attached
  - A weird Deflemask port2note quirk which silences notes is now emulated
  - Automatic port2note off is available but disabled for conversions to MOD due to issues with it in MOD
  - All these quirks are handled by the generated data system, producing a simple quirk-free intermediate representation for other modules to use
- PosJump/PatBreak conversion improved
  - Deflemask quirks relating to PatBreak/PosJump - which ones have priority over others, behavior based on the effect column, etc. are now more accurately handled
  - Orders in Deflemask which are skipped over by a forward PosJump are unplayable, so generated data (and consequently, MOD exports) does not even include those orders
  - Similarly, Deflemask can only have one loop created by a backwards PosJump, and any orders which come after it are unplayable, so generated data reflects that by not including them
  - Any parts of patterns which are skipped over by PatBreak or PosJump are unplayable in Deflemask, and again, this is also reflected in generated data
  - In Deflemask, when a PatBreak effect is used with a non-zero parameter, this prevents the skipped rows in the next pattern from being played, even if you try to loop back to it. For generated data, these orders that start with a row offset are shifted down so that they start at row 0 instead. This is done because ProTracker (and probably other trackers) do not have the same PatBreak/PosJump behavior as Deflemask and would break conversions of DMF songs if they include a loop back to an order with a row offset. In the generated data, the PatBreak is given a 0 parameter, and another PatBreak is added towards the end of the order that would have had the row offset. This has the same effect as in Deflemask without relying on Deflemask's quirks. In the future, a generated data flag could be added if I want the option to preserve these PatBreaks with non-zero parameters and rely on Deflemask-like behavior.
- Better handling of global (channel independent) effects
  - Any empty effects slot can be used in MOD
  - If none are empty, any effects with a lower priority are replaced first
